### PR TITLE
feat: 캘린더 할 일 기능 추가 및 일정 페이지 리팩토링

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Routes, Route, useNavigate } from 'react-router-dom';
+import { Toaster, ToastBar } from 'react-hot-toast';
 import Header from './components/marketing/Header';
 import Hero from './components/marketing/Hero';
 import FeatureShowcase from './components/marketing/FeatureShowcase';
@@ -145,6 +146,58 @@ const App: React.FC = () => {
   return (
 
     <div className="min-h-screen transition-colors duration-300">
+      <Toaster
+        position="top-center"
+        containerStyle={{
+          top: '80vh',
+        }}
+        toastOptions={{
+          duration: 1000,
+          style: {
+            borderRadius: '16px',
+            background: '#0f172a',
+            color: '#f8fafc',
+            fontSize: '14px',
+            fontWeight: 700,
+            padding: '12px 16px',
+          },
+        }}
+      >
+        {(t) => (
+          <ToastBar
+            toast={t}
+            style={{
+              ...t.style,
+              animation: t.visible
+                ? 'toast-slide-up 220ms cubic-bezier(0.22, 1, 0.36, 1)'
+                : 'toast-fade-out 180ms ease-in forwards',
+            }}
+          />
+        )}
+      </Toaster>
+      <style>
+        {`
+          @keyframes toast-slide-up {
+            from {
+              opacity: 0;
+              transform: translateY(14px);
+            }
+            to {
+              opacity: 1;
+              transform: translateY(0);
+            }
+          }
+
+          @keyframes toast-fade-out {
+            from {
+              opacity: 1;
+            }
+            to {
+              opacity: 0;
+            }
+          }
+        `}
+      </style>
       <Routes>
         <Route path="/" element={<HomePage onLogin={openLogin} onSignup={openSignup} onSettings={navigateToSettings} navigateToCalendar={navigateToCalendar} navigateToBookmark={navigateToBookmark} navigateToFeed={navigateToFeed} />} />
         <Route path="/drive" element={<MainLayout><DrivePage onBack={navigateToHome} onSeeAllRecent={navigateToRecentFiles} onSeeAllNodes={navigateToNodes} /></MainLayout>} />

--- a/components/pages/CalendarPage.tsx
+++ b/components/pages/CalendarPage.tsx
@@ -1,245 +1,34 @@
-
-import React, { useState, useRef, useEffect, useMemo } from 'react';
-import UniversalHeader from '../layout/UniversalHeader';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import {
+    Calendar as CalendarIcon,
+    Check,
+    CheckSquare,
+    ChevronLeft,
+    ChevronRight,
+    Clock,
+    MapPin,
+    Plus,
+} from 'lucide-react';
 import CalendarSidebar, { CalendarCategory } from '../calendar/CalendarSidebar';
 import ScrollAwareFab from '../common/ScrollAwareFab';
-import { ChevronLeft, ChevronRight, ChevronUp, ChevronDown, Clock, MapPin, AlignLeft, Plus, X, Check, Trash, Calendar as CalendarIcon } from 'lucide-react';
+import UniversalHeader from '../layout/UniversalHeader';
+import AddCalendarModal from './calendar/AddCalendarModal';
+import CustomCalendarView from './calendar/CustomCalendarView';
+import DayScheduleModal from './calendar/DayScheduleModal';
+import RegisterPage from './calendar/RegisterPage';
+import ScheduleDetailPage from './calendar/ScheduleDetailPage';
+import TodoDetailPage from './calendar/TodoDetailPage';
+import type { AppView, Schedule, Todo } from './calendar/types';
+import { formatMonthYear, toLocalDateStr } from './calendar/utils';
 
-import { motion, AnimatePresence } from 'framer-motion';
-
-
-// --- Types ---
-interface Schedule {
-    id: string;
-    title: string;
-    start: string; // ISO String or YYYY-MM-DD
-    end: string;
-    allDay: boolean;
-    calendarId: string;
-    description?: string;
-    location?: string;
-}
-
-// --- Helper Functions ---
-const getDaysInMonth = (year: number, month: number) => {
-    const date = new Date(year, month, 1);
-    const days = [];
-
-    // Previous month padding
-    const firstDay = date.getDay();
-    const prevMonthLastDay = new Date(year, month, 0).getDate();
-    for (let i = firstDay - 1; i >= 0; i--) {
-        days.push({
-            day: prevMonthLastDay - i,
-            month: month - 1,
-            year: year,
-            isCurrentMonth: false
-        });
-    }
-
-    // Current month days
-    const lastDay = new Date(year, month + 1, 0).getDate();
-    for (let i = 1; i <= lastDay; i++) {
-        days.push({
-            day: i,
-            month: month,
-            year: year,
-            isCurrentMonth: true
-        });
-    }
-
-    // Next month padding (to fill 6 weeks)
-    const remaining = 42 - days.length;
-    for (let i = 1; i <= remaining; i++) {
-        days.push({
-            day: i,
-            month: month + 1,
-            year: year,
-            isCurrentMonth: false
-        });
-    }
-
-    return days;
-};
-
-const formatDate = (date: Date) => {
-    return `${date.getFullYear()}년 ${date.getMonth() + 1}월`;
-};
-
-// --- Custom Calendar View Component ---
-const CustomCalendarView: React.FC<{
-    date: Date;
-    schedules: Schedule[];
-    calendars: CalendarCategory[];
-    onDateClick: (date: Date) => void;
-    onEventClick: (schedule: Schedule) => void;
-}> = ({ date, schedules, calendars, onDateClick, onEventClick }) => {
-    const year = date.getFullYear();
-    const month = date.getMonth();
-    const days = useMemo(() => getDaysInMonth(year, month), [year, month]);
-    const today = new Date();
-
-    // Assign lanes to schedules to prevent overlap
-    const scheduleLanes = useMemo(() => {
-        const slots: string[][] = Array(42).fill(0).map(() => []);
-        // Pick visible and sorted schedules (all-day first, then longer ones)
-        const sortedSchedules = [...schedules]
-            .filter(s => calendars.find(c => c.id === s.calendarId)?.isVisible)
-            .sort((a, b) => {
-                if (a.allDay !== b.allDay) return a.allDay ? -1 : 1;
-                const aDuration = new Date(a.end).getTime() - new Date(a.start).getTime();
-                const bDuration = new Date(b.end).getTime() - new Date(b.start).getTime();
-                return bDuration - aDuration;
-            });
-
-        const assigned: { [id: string]: number } = {};
-
-        sortedSchedules.forEach(s => {
-            const sStart = new Date(s.start);
-            const sEnd = new Date(s.end);
-            sStart.setHours(0, 0, 0, 0);
-            sEnd.setHours(0, 0, 0, 0);
-
-            let firstIdx = -1;
-            let lastIdx = -1;
-
-            days.forEach((d, i) => {
-                const cellDate = new Date(d.year, d.month, d.day);
-                if (cellDate >= sStart && cellDate <= sEnd) {
-                    if (firstIdx === -1) firstIdx = i;
-                    lastIdx = i;
-                }
-            });
-
-            if (firstIdx !== -1) {
-                let lane = 0;
-                while (true) {
-                    let clear = true;
-                    for (let i = firstIdx; i <= lastIdx; i++) {
-                        if (slots[i][lane]) {
-                            clear = false;
-                            break;
-                        }
-                    }
-                    if (clear) {
-                        for (let i = firstIdx; i <= lastIdx; i++) slots[i][lane] = s.id;
-                        assigned[s.id] = lane;
-                        break;
-                    }
-                    lane++;
-                }
-            }
-        });
-
-        return assigned;
-    }, [days, schedules, calendars]);
-
-    return (
-        <div className="flex flex-col h-full select-none">
-            {/* Week Header */}
-            <div className="grid grid-cols-7 border-b border-slate-100 dark:border-white/5">
-                {['일', '월', '화', '수', '목', '금', '토'].map((d, i) => (
-                    <div key={d} className={`text-[15px] text-center font-black py-2 uppercase tracking-tight ${i === 0 ? 'text-red-400' : i === 6 ? 'text-blue-400' : 'text-slate-400'}`}>
-                        {d}
-                    </div>
-                ))}
-            </div>
-
-            {/* Days Grid */}
-            <div className="grid grid-cols-7 flex-1">
-                {days.map((d, i) => {
-                    const cellDate = new Date(d.year, d.month, d.day);
-                    const isToday = today.toDateString() === cellDate.toDateString();
-
-                    // Calculate lanes for this cell
-                    const dayLanes: (Schedule | null)[] = [];
-                    schedules.forEach(s => {
-                        const lane = scheduleLanes[s.id];
-                        if (lane !== undefined) {
-                            const sStart = new Date(s.start);
-                            const sEnd = new Date(s.end);
-                            sStart.setHours(0, 0, 0, 0);
-                            sEnd.setHours(0, 0, 0, 0);
-                            if (cellDate >= sStart && cellDate <= sEnd) {
-                                dayLanes[lane] = s;
-                            }
-                        }
-                    });
-
-                    return (
-                        <div
-                            key={`${d.year}-${d.month}-${d.day}-${i}`}
-                            onClick={() => onDateClick(cellDate)}
-                            className={`border-r border-b border-slate-50 dark:border-white/5 pt-0.5 pb-1 min-h-0 flex flex-col transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/20 cursor-pointer ${!d.isCurrentMonth ? 'opacity-30' : ''}`}
-                        >
-                            <span className={`text-[13px] font-black w-5 h-5 flex items-center justify-center rounded-full ml-auto mb-0.5 mr-1 ${isToday ? 'bg-teal-500 text-white' : 'text-slate-400'}`}>
-                                {d.day}
-                            </span>
-                            <div className="flex flex-col gap-0.5">
-                                {Array.from({ length: Math.max(3, Math.min(dayLanes.length, 4)) }).map((_, laneIdx) => {
-                                    const s = dayLanes[laneIdx];
-                                    if (!s) return <div key={laneIdx} className="h-4" />;
-
-                                    const cal = calendars.find(c => c.id === s.calendarId);
-                                    const sStart = new Date(s.start);
-                                    const sEnd = new Date(s.end);
-                                    sStart.setHours(0, 0, 0, 0);
-                                    sEnd.setHours(0, 0, 0, 0);
-
-                                    const isStart = sStart.getTime() === cellDate.getTime();
-                                    const isEnd = sEnd.getTime() === cellDate.getTime();
-                                    const isMultiDay = sStart.getTime() !== sEnd.getTime();
-                                    const isWeekStart = i % 7 === 0;
-
-                                    if (s.allDay || isMultiDay) {
-                                        const showTitle = isStart || isWeekStart;
-                                        return (
-                                            <div
-                                                key={s.id}
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    onEventClick(s);
-                                                }}
-                                                className={`h-4 text-[9px] py-0.5 truncate text-white font-bold opacity-90 transition-transform active:scale-95 relative ${!isEnd ? 'w-[calc(100%+1px)] z-10' : 'w-full'} ${isStart ? 'rounded-l-[5px]' : ''} ${isEnd ? 'rounded-r-[5px]' : ''} ${showTitle ? 'px-1.5' : 'px-0'}`}
-                                                style={{ backgroundColor: cal?.color || '#ccc' }}
-                                            >
-                                                {showTitle && s.title}
-                                            </div>
-                                        );
-                                    }
-
-                                    const barColor = cal?.color || '#ccc';
-                                    return (
-                                        <div
-                                            key={s.id}
-                                            onClick={(e) => {
-                                                e.stopPropagation();
-                                                onEventClick(s);
-                                            }}
-                                            className="h-4 flex items-center gap-1 text-[9px] font-bold text-slate-700 dark:text-slate-300 transition-transform active:scale-95"
-                                        >
-                                            <div className="w-0.5 h-3 flex-shrink-0" style={{ backgroundColor: barColor }} />
-                                            <span className="truncate">{s.title}</span>
-                                        </div>
-                                    );
-                                })}
-                                {dayLanes.length > 4 && (
-                                    <div className="h-4 text-[9px] font-bold text-slate-400 dark:text-slate-500 flex items-center pl-1">
-                                        ...
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                    );
-                })}
-            </div>
-        </div>
-    );
-};
-
-// --- Main Page Component ---
 const CalendarPage: React.FC<{ onBack: () => void }> = ({ onBack }) => {
+    const [view, setView] = useState<AppView>('calendar');
+    const [registerInitialTab, setRegisterInitialTab] = useState<'schedule' | 'todo'>('schedule');
     const [isSidebarOpen, setSidebarOpen] = useState(false);
+    const [isAddCalendarModalOpen, setIsAddCalendarModalOpen] = useState(false);
+    const [isDayScheduleModalOpen, setIsDayScheduleModalOpen] = useState(false);
+
     const [calendars, setCalendars] = useState<CalendarCategory[]>([
         { id: 'my', name: '나의 캘린더', color: '#10b981', isVisible: true },
         { id: 'concert', name: '콘서트', color: '#8b5cf6', isVisible: true },
@@ -252,27 +41,25 @@ const CalendarPage: React.FC<{ onBack: () => void }> = ({ onBack }) => {
         { id: '4', title: '설날 연휴', start: '2026-01-28', end: '2026-01-31', allDay: true, calendarId: 'my' },
         { id: '5', title: '프로젝트 런칭', start: '2026-01-18T10:00:00', end: '2026-01-20T12:00:00', allDay: true, calendarId: 'company' },
     ]);
+    const [todos, setTodos] = useState<Todo[]>([]);
 
-    const [isScheduleModalOpen, setIsScheduleModalOpen] = useState(false);
-    const [isAddCalendarModalOpen, setIsAddCalendarModalOpen] = useState(false);
-    const [isDayScheduleModalOpen, setIsDayScheduleModalOpen] = useState(false);
     const [selectedDate, setSelectedDate] = useState<Date | null>(null);
     const [editingSchedule, setEditingSchedule] = useState<Schedule | null>(null);
+    const [editingTodo, setEditingTodo] = useState<Todo | null>(null);
     const [daySchedules, setDaySchedules] = useState<Schedule[]>([]);
+    const [dayTodos, setDayTodos] = useState<Todo[]>([]);
     const [currentDate, setCurrentDate] = useState(new Date());
     const [direction, setDirection] = useState(0);
 
     const mainContentRef = useRef<HTMLDivElement>(null);
-    const scrollTimeout = useRef<NodeJS.Timeout | null>(null);
+    const scrollTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
     const sidebarHistoryRef = useRef(false);
-
-    // Scroll interpolation states
-    const [calendarHeight, setCalendarHeight] = useState(window.innerHeight - 192); // Adjusted for listRoom 64 (64+64+64)
+    const overlayHistoryRef = useRef(false);
+    const [calendarHeight, setCalendarHeight] = useState(window.innerHeight - 192);
     const [scrollRatio, setScrollRatio] = useState(0);
 
-    const toggleCalendarVisibility = (id: string) => {
-        setCalendars(prev => prev.map(c => c.id === id ? { ...c, isVisible: !c.isVisible } : c));
-    };
+    const toggleCalendarVisibility = (id: string) =>
+        setCalendars((prev) => prev.map((calendar) => calendar.id === id ? { ...calendar, isVisible: !calendar.isVisible } : calendar));
 
     const openSidebar = () => {
         setSidebarOpen(true);
@@ -285,105 +72,196 @@ const CalendarPage: React.FC<{ onBack: () => void }> = ({ onBack }) => {
     const closeSidebar = () => {
         if (sidebarHistoryRef.current) {
             window.history.back();
-        } else {
-            setSidebarOpen(false);
+            return;
         }
+
+        setSidebarOpen(false);
     };
+
+    const closeOverlayToCalendar = () => {
+        if (overlayHistoryRef.current) {
+            window.history.back();
+            return;
+        }
+
+        overlayHistoryRef.current = false;
+        setEditingSchedule(null);
+        setEditingTodo(null);
+        setView('calendar');
+    };
+
+    const allVisibleSchedules = useMemo(() => {
+        const visibleIds = calendars.filter((calendar) => calendar.isVisible).map((calendar) => calendar.id);
+        return schedules.filter((schedule) => visibleIds.includes(schedule.calendarId));
+    }, [schedules, calendars]);
 
     const getSchedulesForDate = (date: Date) => {
         const target = new Date(date);
         target.setHours(0, 0, 0, 0);
 
-        return allVisibleSchedules
-            .filter(s => {
-                const start = new Date(s.start);
-                const end = new Date(s.end);
-                start.setHours(0, 0, 0, 0);
-                end.setHours(0, 0, 0, 0);
-                return target >= start && target <= end;
-            })
-            .sort((a, b) => a.start.localeCompare(b.start));
+        return allVisibleSchedules.filter((schedule) => {
+            const start = new Date(schedule.start);
+            start.setHours(0, 0, 0, 0);
+            const end = new Date(schedule.end);
+            end.setHours(0, 0, 0, 0);
+            return target >= start && target <= end;
+        }).sort((a, b) => a.start.localeCompare(b.start));
+    };
+
+    const getTodosForDate = (date: Date): Todo[] =>
+        todos.filter((todo) => todo.date === toLocalDateStr(date));
+
+    const handleToggleTodoComplete = (id: string) => {
+        setTodos((prev) => prev.map((todo) => todo.id === id ? { ...todo, completed: !todo.completed } : todo));
+        setDayTodos((prev) => prev.map((todo) => todo.id === id ? { ...todo, completed: !todo.completed } : todo));
+        setEditingTodo((prev) => prev?.id === id ? { ...prev, completed: !prev.completed } : prev);
+    };
+
+    const handleDeleteSchedule = (id: string) => {
+        setSchedules((prev) => prev.filter((schedule) => schedule.id !== id));
+        setEditingSchedule(null);
+        closeOverlayToCalendar();
+    };
+
+    const handleDeleteTodo = (id: string) => {
+        setTodos((prev) => prev.filter((todo) => todo.id !== id));
+        setEditingTodo(null);
+        closeOverlayToCalendar();
+    };
+
+    const handleSaveSchedule = (data: Omit<Schedule, 'id'>) => {
+        if (editingSchedule) {
+            const updated = { ...editingSchedule, ...data };
+            setSchedules((prev) => prev.map((schedule) => schedule.id === editingSchedule.id ? updated : schedule));
+            setEditingSchedule(updated);
+            setView('schedule-detail');
+            return;
+        }
+
+        setSchedules((prev) => [...prev, { ...data, id: Math.random().toString() }]);
+        closeOverlayToCalendar();
+    };
+
+    const handleSaveTodo = (data: Omit<Todo, 'id' | 'completed' | 'createdAt'>) => {
+        if (editingTodo) {
+            const updated = { ...editingTodo, ...data };
+            setTodos((prev) => prev.map((todo) => todo.id === editingTodo.id ? updated : todo));
+            setEditingTodo(updated);
+            setView('todo-detail');
+            return;
+        }
+
+        setTodos((prev) => [...prev, {
+            ...data,
+            id: Math.random().toString(),
+            completed: false,
+            createdAt: new Date().toISOString(),
+        }]);
+        closeOverlayToCalendar();
+    };
+
+    const handleRegisterCancel = () => {
+        closeOverlayToCalendar();
     };
 
     const handleDateClick = (date: Date) => {
-        const matches = getSchedulesForDate(date);
-
+        const matchSchedules = getSchedulesForDate(date);
+        const matchTodos = getTodosForDate(date);
         setSelectedDate(date);
-        setEditingSchedule(null);
-        if (matches.length > 0) {
-            setDaySchedules(matches);
+
+        if (matchSchedules.length > 0 || matchTodos.length > 0) {
+            setDaySchedules(matchSchedules);
+            setDayTodos(matchTodos);
             setIsDayScheduleModalOpen(true);
-            window.history.pushState({ dayScheduleModal: true }, '');
-        } else {
-            setIsScheduleModalOpen(true);
+            return;
         }
+
+        setEditingSchedule(null);
+        setEditingTodo(null);
+        setRegisterInitialTab('schedule');
+        setView('register');
     };
 
     const handleEventClick = (schedule: Schedule) => {
-        const eventDate = new Date(schedule.start);
-        const matches = getSchedulesForDate(eventDate);
+        setEditingSchedule(schedule);
+        setView('schedule-detail');
+    };
 
-        setSelectedDate(eventDate);
-        setEditingSchedule(null);
-        setDaySchedules(matches);
-        setIsDayScheduleModalOpen(true);
-        window.history.pushState({ dayScheduleModal: true }, '');
+    const handleTodoClick = (todo: Todo) => {
+        setEditingTodo(todo);
+        setView('todo-detail');
     };
 
     const handleDayScheduleSelect = (schedule: Schedule) => {
         setEditingSchedule(schedule);
         setIsDayScheduleModalOpen(false);
-        setIsScheduleModalOpen(true);
+        setView('schedule-detail');
+    };
+
+    const handleDayTodoSelect = (todo: Todo) => {
+        setEditingTodo(todo);
+        setIsDayScheduleModalOpen(false);
+        setView('todo-detail');
+    };
+
+    const handleCreateFromDay = (tab: 'schedule' | 'todo') => {
+        setEditingSchedule(null);
+        setEditingTodo(null);
+        setRegisterInitialTab(tab);
+        setIsDayScheduleModalOpen(false);
+        setView('register');
     };
 
     useEffect(() => {
+        if (view !== 'calendar' && !overlayHistoryRef.current) {
+            window.history.pushState({ calendarOverlay: true }, '');
+            overlayHistoryRef.current = true;
+        }
+    }, [view]);
+
+    useEffect(() => {
         const handlePopState = () => {
+            if (view !== 'calendar') {
+                overlayHistoryRef.current = false;
+                setEditingSchedule(null);
+                setEditingTodo(null);
+                setView('calendar');
+                return;
+            }
+
             if (isSidebarOpen) {
                 setSidebarOpen(false);
                 sidebarHistoryRef.current = false;
                 return;
             }
+
             if (isDayScheduleModalOpen) {
                 setIsDayScheduleModalOpen(false);
             }
         };
 
         window.addEventListener('popstate', handlePopState);
-        return () => {
-            window.removeEventListener('popstate', handlePopState);
-        };
-    }, [isDayScheduleModalOpen, isSidebarOpen]);
+        return () => window.removeEventListener('popstate', handlePopState);
+    }, [isDayScheduleModalOpen, isSidebarOpen, view]);
 
     const handleSwipe = (dir: 'prev' | 'next') => {
-        const newDate = new Date(currentDate);
-        if (dir === 'prev') {
-            newDate.setMonth(newDate.getMonth() - 1);
-            setDirection(-1);
-        } else {
-            newDate.setMonth(newDate.getMonth() + 1);
-            setDirection(1);
-        }
-        setCurrentDate(newDate);
+        const nextDate = new Date(currentDate);
+        nextDate.setMonth(nextDate.getMonth() + (dir === 'next' ? 1 : -1));
+        setDirection(dir === 'next' ? 1 : -1);
+        setCurrentDate(nextDate);
     };
 
-
-
     const prevMonthDate = useMemo(() => {
-        const d = new Date(currentDate);
-        d.setMonth(d.getMonth() - 1);
-        return d;
+        const date = new Date(currentDate);
+        date.setMonth(date.getMonth() - 1);
+        return date;
     }, [currentDate]);
 
     const nextMonthDate = useMemo(() => {
-        const d = new Date(currentDate);
-        d.setMonth(d.getMonth() + 1);
-        return d;
+        const date = new Date(currentDate);
+        date.setMonth(date.getMonth() + 1);
+        return date;
     }, [currentDate]);
-
-    const allVisibleSchedules = useMemo(() => {
-        const visibleCalendarIds = calendars.filter(c => c.isVisible).map(c => c.id);
-        return schedules.filter(s => visibleCalendarIds.includes(s.calendarId));
-    }, [schedules, calendars]);
 
     const thisWeekSchedules = useMemo(() => {
         const today = new Date();
@@ -392,73 +270,72 @@ const CalendarPage: React.FC<{ onBack: () => void }> = ({ onBack }) => {
         endOfWeek.setDate(today.getDate() + 7);
         endOfWeek.setHours(23, 59, 59, 999);
 
-        return allVisibleSchedules.filter(s => {
-            const start = new Date(s.start);
-            const end = new Date(s.end);
+        return allVisibleSchedules.filter((schedule) => {
+            const start = new Date(schedule.start);
+            const end = new Date(schedule.end);
             return (start >= today && start <= endOfWeek) || (end >= today && end <= endOfWeek) || (start <= today && end >= endOfWeek);
         }).sort((a, b) => a.start.localeCompare(b.start));
     }, [allVisibleSchedules]);
 
-    // Handle Scroll for shrinking calendar
+    const thisWeekTodos = useMemo(() => {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        const endOfWeek = new Date(today);
+        endOfWeek.setDate(today.getDate() + 7);
+
+        return todos.filter((todo) => {
+            const date = new Date(todo.date);
+            return date >= today && date <= endOfWeek;
+        }).sort((a, b) => a.date.localeCompare(b.date));
+    }, [todos]);
+
     useEffect(() => {
-        const updateH = () => {
+        const updateHeight = () => {
             if (!mainContentRef.current) return;
+
             const scrollTop = mainContentRef.current.scrollTop;
             const isDesktop = window.innerWidth >= 768;
-            const bottomMenuH = isDesktop ? 0 : 64;
-            const headerH = 64;
-            const screenH = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+            const bottomMenuHeight = isDesktop ? 0 : 64;
+            const screenHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+            const listRoom = 64;
+            const maxHeight = screenHeight - 64 - bottomMenuHeight - listRoom;
+            const threshold = 40;
+            const effectiveScroll = scrollTop > threshold ? scrollTop - threshold : 0;
+            const ratio = Math.min(1, effectiveScroll / (maxHeight / 1.2));
 
-            const listRoom = 64; // Adjusted to show only the title row
-            const maxH = screenH - headerH - bottomMenuH - listRoom;
-            const minH = 0; // Changed from 160 to 0 to completely hide
-            const maxScroll = maxH; // Entire height can be scrolled away
-
-            const threshold = 40; // Slightly reduced threshold
-            let effectiveScroll = 0;
-            if (scrollTop > threshold) effectiveScroll = scrollTop - threshold;
-
-            const ratio = Math.min(1, effectiveScroll / (maxScroll / 1.2));
-            const newHeight = Math.max(minH, maxH - effectiveScroll);
-
-            setCalendarHeight(newHeight);
+            setCalendarHeight(Math.max(0, maxHeight - effectiveScroll));
             setScrollRatio(ratio);
 
             if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
             scrollTimeout.current = setTimeout(() => {
                 if (!mainContentRef.current) return;
-                const curScroll = mainContentRef.current.scrollTop;
-                if (curScroll > 0 && curScroll < threshold + maxScroll) {
-                    const targetScroll = curScroll > (threshold + maxScroll / 4) ? threshold + maxScroll : 0;
-                    mainContentRef.current.scrollTo({ top: targetScroll, behavior: 'smooth' });
+
+                const currentScrollTop = mainContentRef.current.scrollTop;
+                if (currentScrollTop > 0 && currentScrollTop < threshold + maxHeight) {
+                    const target = currentScrollTop > (threshold + maxHeight / 4) ? threshold + maxHeight : 0;
+                    mainContentRef.current.scrollTo({ top: target, behavior: 'smooth' });
                 }
             }, 150);
         };
 
-        const div = mainContentRef.current;
-        if (div) {
-            div.addEventListener('scroll', updateH);
-            window.addEventListener('resize', updateH);
-            updateH();
+        const scrollElement = mainContentRef.current;
+        if (scrollElement) {
+            scrollElement.addEventListener('scroll', updateHeight);
+            window.addEventListener('resize', updateHeight);
+            updateHeight();
         }
+
         return () => {
             if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
-            div?.removeEventListener('scroll', updateH);
-            window.removeEventListener('resize', updateH);
+            scrollElement?.removeEventListener('scroll', updateHeight);
+            window.removeEventListener('resize', updateHeight);
         };
     }, []);
 
     return (
         <div className="min-h-screen flex flex-col bg-slate-50 dark:bg-[#0f172a] transition-colors">
-            {/* Fixed Header */}
-            <UniversalHeader
-                title="캘린더"
-                onBack={onBack}
-                showBack={false}
-                onMenuClick={openSidebar}
-            />
+            <UniversalHeader title="캘린더" onBack={onBack} showBack={false} onMenuClick={openSidebar} />
 
-            {/* Content Wrapper */}
             <div className="flex flex-1 overflow-hidden h-[calc(100vh-64px)]">
                 <CalendarSidebar
                     calendars={calendars}
@@ -468,25 +345,21 @@ const CalendarPage: React.FC<{ onBack: () => void }> = ({ onBack }) => {
                     onClose={closeSidebar}
                 />
 
-                {/* Main Content */}
                 <main
-                    ref={(node) => {
-                        mainContentRef.current = node;
-                    }}
+                    ref={(node) => { mainContentRef.current = node; }}
                     data-fab-scroll-container
                     className="flex-1 overflow-y-auto w-full relative md:ml-64 custom-scrollbar"
                 >
                     <motion.div
-                        className="sticky top-0 z-20 bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-white/5 overflow-hidden flex-shrink-0 flex flex-col"
+                        className="sticky top-0 z-20 bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-white/5 overflow-hidden flex flex-col"
                         animate={{ height: calendarHeight }}
-                        transition={{ type: "spring", stiffness: 200, damping: 25, mass: 0.5 }}
+                        transition={{ type: 'spring', stiffness: 200, damping: 25, mass: 0.5 }}
                     >
-                        {/* Custom Header Toolbar */}
                         <div className="flex items-center justify-between px-6 py-3 bg-white dark:bg-slate-900 flex-shrink-0">
                             <h2 className="text-lg font-black tracking-tight text-slate-800 dark:text-slate-200">
-                                {formatDate(currentDate)}
+                                {formatMonthYear(currentDate)}
                             </h2>
-                            <div className="flex items-center gap-2">
+                            <div className="flex items-center gap-1">
                                 <button onClick={() => handleSwipe('prev')} className="p-1.5 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-full text-slate-400 hover:text-teal-500 transition-colors">
                                     <ChevronLeft size={20} />
                                 </button>
@@ -498,7 +371,6 @@ const CalendarPage: React.FC<{ onBack: () => void }> = ({ onBack }) => {
                                         setCurrentDate(now);
                                     }}
                                     className="p-1.5 text-teal-600 dark:text-teal-400 hover:bg-teal-50 dark:hover:bg-teal-500/10 rounded-full transition-colors flex items-center justify-center"
-                                    title="오늘로 이동"
                                 >
                                     <div className="w-[19px] h-[19px] border-[2px] border-current rounded-[4px] flex items-center justify-center text-[9px] font-black mt-0.5">
                                         {new Date().getDate()}
@@ -510,157 +382,242 @@ const CalendarPage: React.FC<{ onBack: () => void }> = ({ onBack }) => {
                             </div>
                         </div>
 
-                        {/* Carousel Wrapper */}
-                        <div
-                            className="flex-1 overflow-hidden relative"
-                            style={{
-                                opacity: 1 - (scrollRatio * 0.3),
-                                transform: `scale(${1 - scrollRatio * 0.02})`,
-                                transformOrigin: 'top center'
-                            }}
-                        >
+                        <div className="flex-1 overflow-hidden relative" style={{ opacity: 1 - scrollRatio * 0.3, transform: `scale(${1 - scrollRatio * 0.02})`, transformOrigin: 'top center' }}>
                             <motion.div
                                 key={currentDate.toISOString()}
                                 drag="x"
                                 dragConstraints={{ left: 0, right: 0 }}
                                 dragElastic={0.6}
                                 onDragEnd={(_, info) => {
-                                    const threshold = 100;
-                                    if (info.offset.x < -threshold) handleSwipe('next');
-                                    else if (info.offset.x > threshold) handleSwipe('prev');
+                                    if (info.offset.x < -30) handleSwipe('next');
+                                    else if (info.offset.x > 30) handleSwipe('prev');
                                 }}
                                 initial={{ x: direction * 100, opacity: 0 }}
                                 animate={{ x: 0, opacity: 1 }}
-                                transition={{ type: "spring", stiffness: 300, damping: 30 }}
+                                transition={{ type: 'spring', stiffness: 300, damping: 30 }}
                                 className="h-full flex items-stretch w-full cursor-grab active:cursor-grabbing"
                             >
                                 <div className="absolute right-full top-0 bottom-0 w-full px-2 opacity-20">
-                                    <CustomCalendarView date={prevMonthDate} schedules={allVisibleSchedules} calendars={calendars} onDateClick={() => { }} onEventClick={() => { }} />
+                                    <CustomCalendarView date={prevMonthDate} schedules={allVisibleSchedules} todos={[]} calendars={calendars} onDateClick={() => { }} onEventClick={() => { }} onTodoClick={() => { }} />
                                 </div>
                                 <div className="w-full h-full flex-shrink-0">
-                                    <CustomCalendarView date={currentDate} schedules={allVisibleSchedules} calendars={calendars} onDateClick={handleDateClick} onEventClick={handleEventClick} />
+                                    <CustomCalendarView date={currentDate} schedules={allVisibleSchedules} todos={todos} calendars={calendars} onDateClick={handleDateClick} onEventClick={handleEventClick} onTodoClick={handleTodoClick} />
                                 </div>
                                 <div className="absolute left-full top-0 bottom-0 w-full px-2 opacity-20">
-                                    <CustomCalendarView date={nextMonthDate} schedules={allVisibleSchedules} calendars={calendars} onDateClick={() => { }} onEventClick={() => { }} />
+                                    <CustomCalendarView date={nextMonthDate} schedules={allVisibleSchedules} todos={[]} calendars={calendars} onDateClick={() => { }} onEventClick={() => { }} onTodoClick={() => { }} />
                                 </div>
                             </motion.div>
                         </div>
                     </motion.div>
 
-                    {/* Schedule List */}
-                    <div
-                        className="flex-1 p-5 space-y-6 pb-32"
-                        style={{ minHeight: 'calc(100vh - 64px)' }}
-                    >
-                        <div className="flex items-center justify-between">
-                            <h3 className="text-lg font-black tracking-tight flex items-center gap-2">
-                                <span className="w-1.5 h-6 bg-teal-500 rounded-full" />
+                    <div className="flex-1 p-5 space-y-6 pb-32" style={{ minHeight: 'calc(100vh - 64px)' }}>
+                        <div>
+                            <h3 className="text-base font-black tracking-tight flex items-center gap-2 mb-3">
+                                <span className="w-1 h-5 bg-teal-500 rounded-full" />
                                 다가오는 일정
                             </h3>
+                            {thisWeekSchedules.length === 0 ? (
+                                <div className="flex flex-col items-center justify-center py-12 text-slate-300 dark:text-slate-600">
+                                    <CalendarIcon size={28} className="mb-3" />
+                                    <p className="text-sm font-semibold">일정이 없습니다</p>
+                                </div>
+                            ) : (
+                                <div className="space-y-2">
+                                    {thisWeekSchedules.map((schedule) => {
+                                        const calendar = calendars.find((item) => item.id === schedule.calendarId);
+                                        const start = new Date(schedule.start);
+                                        const isToday = start.toDateString() === new Date().toDateString();
 
-
+                                        return (
+                                            <motion.button
+                                                layout
+                                                initial={{ opacity: 0, y: 8 }}
+                                                animate={{ opacity: 1, y: 0 }}
+                                                key={schedule.id}
+                                                onClick={() => handleEventClick(schedule)}
+                                                className="w-full text-left bg-white dark:bg-slate-800/40 rounded-2xl border border-slate-100 dark:border-white/5 hover:border-teal-400/50 transition-all flex items-center gap-3 p-3 group"
+                                            >
+                                                <div className="flex flex-col items-center justify-center w-12 h-12 bg-slate-50 dark:bg-slate-900 rounded-xl flex-shrink-0">
+                                                    <span className={`text-[10px] font-bold ${isToday ? 'text-teal-500' : 'text-slate-400'}`}>
+                                                        {start.toLocaleDateString('ko-KR', { weekday: 'short' })}
+                                                    </span>
+                                                    <span className={`text-lg font-black leading-none ${isToday ? 'text-teal-500' : 'text-slate-800 dark:text-white'}`}>
+                                                        {start.getDate()}
+                                                    </span>
+                                                </div>
+                                                <div className="w-0.5 h-10 rounded-full flex-shrink-0" style={{ backgroundColor: calendar?.color }} />
+                                                <div className="flex-1 min-w-0">
+                                                    <p className="font-bold text-sm text-slate-900 dark:text-white truncate group-hover:text-teal-600 dark:group-hover:text-teal-400">{schedule.title}</p>
+                                                    <div className="flex gap-2 text-xs text-slate-400 dark:text-slate-500 mt-0.5">
+                                                        <span className="flex items-center gap-0.5">
+                                                            <Clock size={11} />
+                                                            {schedule.allDay ? '종일' : start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false })}
+                                                        </span>
+                                                        {schedule.location && <span className="flex items-center gap-0.5 truncate"><MapPin size={11} />{schedule.location}</span>}
+                                                    </div>
+                                                </div>
+                                            </motion.button>
+                                        );
+                                    })}
+                                </div>
+                            )}
                         </div>
 
-                        {thisWeekSchedules.length === 0 ? (
-                            <div className="flex flex-col items-center justify-center py-20 text-slate-400 text-center">
-                                <CalendarIcon size={32} className="opacity-20 mb-4" />
-                                <p className="font-bold">표시할 일정이 없습니다.</p>
+                        <div>
+                            <div className="flex items-center justify-between mb-3">
+                                <h3 className="text-base font-black tracking-tight flex items-center gap-2">
+                                    <span className="w-1 h-5 bg-violet-500 rounded-full" />
+                                    이번 주 할 일
+                                </h3>
+                                <button
+                                    onClick={() => {
+                                        setEditingTodo(null);
+                                        setEditingSchedule(null);
+                                        setSelectedDate(new Date());
+                                        setRegisterInitialTab('todo');
+                                        setView('register');
+                                    }}
+                                    className="p-1.5 hover:bg-violet-50 dark:hover:bg-violet-500/10 rounded-full text-slate-400 hover:text-violet-500 transition-colors"
+                                >
+                                    <Plus size={16} />
+                                </button>
                             </div>
-                        ) : (
-                            <div className="space-y-3">
-                                {thisWeekSchedules.map(s => {
-                                    const cal = calendars.find(c => c.id === s.calendarId);
-                                    const start = new Date(s.start);
-                                    const isToday = start.toDateString() === new Date().toDateString();
-                                    return (
-                                        <motion.button
-                                            layout
-                                            initial={{ opacity: 0, y: 10 }}
-                                            animate={{ opacity: 1, y: 0 }}
-                                            key={s.id}
-                                            onClick={() => handleEventClick(s)}
-                                            className="w-full text-left bg-white dark:bg-slate-800/40 p-2 rounded-2xl border border-slate-200 dark:border-white/5 hover:border-teal-500/50 transition-all flex items-center gap-4 group"
-                                        >
-                                            <div className="flex flex-col items-center justify-center min-w-[50px] py-1 bg-slate-50 dark:bg-slate-900 rounded-xl">
-                                                <span className={`text-[10px] font-bold ${isToday ? 'text-teal-500' : 'text-slate-400 uppercase'}`}>{start.toLocaleDateString('ko-KR', { weekday: 'short' })}</span>
-                                                <span className={`text-lg font-black ${isToday ? 'text-teal-500' : 'text-slate-900 dark:text-white'}`}>{start.getDate()}</span>
-                                            </div>
-                                            <div className="w-1 h-10 rounded-full flex-shrink-0" style={{ backgroundColor: cal?.color }} />
-                                            <div className="flex-1 min-w-0">
-                                                <h4 className="font-bold text-slate-900 dark:text-white truncate group-hover:text-teal-600 dark:group-hover:text-teal-400">{s.title}</h4>
-                                                <div className="flex gap-x-3 text-xs text-slate-500 dark:text-gray-400">
-                                                    <div className="flex items-center gap-1"><Clock size={12} /> {s.allDay ? '종일' : start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false })}</div>
-                                                    {s.location && <div className="flex items-center gap-1 truncate"><MapPin size={12} /> {s.location}</div>}
-                                                </div>
-                                            </div>
-                                        </motion.button>
-                                    );
-                                })}
-                            </div>
-                        )}
+                            {thisWeekTodos.length === 0 ? (
+                                <div className="flex flex-col items-center justify-center py-12 text-slate-300 dark:text-slate-600">
+                                    <CheckSquare size={28} className="mb-3" />
+                                    <p className="text-sm font-semibold">할 일이 없습니다</p>
+                                </div>
+                            ) : (
+                                <div className="space-y-2">
+                                    {thisWeekTodos.map((todo) => {
+                                        const todoDate = new Date(todo.date + 'T00:00:00');
+                                        const isToday = todoDate.toDateString() === new Date().toDateString();
+
+                                        return (
+                                            <motion.div
+                                                layout
+                                                initial={{ opacity: 0, y: 8 }}
+                                                animate={{ opacity: 1, y: 0 }}
+                                                key={todo.id}
+                                                className={`bg-white dark:bg-slate-800/40 rounded-2xl border border-slate-100 dark:border-white/5 transition-all flex items-center gap-3 p-3 ${todo.completed ? 'opacity-60' : ''}`}
+                                            >
+                                                <button
+                                                    onClick={() => handleToggleTodoComplete(todo.id)}
+                                                    className={`w-6 h-6 rounded-lg border-2 flex-shrink-0 flex items-center justify-center transition-colors ${todo.completed ? 'bg-violet-500 border-violet-500' : 'border-slate-300 dark:border-slate-600 hover:border-violet-400'}`}
+                                                >
+                                                    {todo.completed && <Check size={12} className="text-white" strokeWidth={3} />}
+                                                </button>
+                                                <button onClick={() => handleTodoClick(todo)} className="flex-1 min-w-0 flex items-center gap-3 text-left">
+                                                    <div className="flex flex-col items-center justify-center w-12 h-12 bg-slate-50 dark:bg-slate-900 rounded-xl flex-shrink-0">
+                                                        <span className={`text-[10px] font-bold ${isToday ? 'text-violet-500' : 'text-slate-400'}`}>
+                                                            {todoDate.toLocaleDateString('ko-KR', { weekday: 'short' })}
+                                                        </span>
+                                                        <span className={`text-lg font-black leading-none ${isToday ? 'text-violet-500' : 'text-slate-800 dark:text-white'}`}>
+                                                            {todoDate.getDate()}
+                                                        </span>
+                                                    </div>
+                                                    <div className="flex-1 min-w-0">
+                                                        <p className={`font-bold text-sm truncate ${todo.completed ? 'line-through text-slate-400 dark:text-slate-500' : 'text-slate-900 dark:text-white'}`}>{todo.title}</p>
+                                                        <p className="text-xs text-slate-400 mt-0.5 flex items-center gap-0.5">
+                                                            <Clock size={11} />
+                                                            {todo.allDay ? '하루종일' : todo.time || ''}
+                                                        </p>
+                                                    </div>
+                                                </button>
+                                            </motion.div>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
                     </div>
                 </main>
             </div>
 
-            {/* Modals */}
             <AnimatePresence>
-                {isScheduleModalOpen && (
-                    <ScheduleModal
-                        isOpen={isScheduleModalOpen}
-                        onClose={() => setIsScheduleModalOpen(false)}
-                        selectedDate={selectedDate || new Date()}
-                        editingSchedule={editingSchedule}
-                        calendars={calendars}
-                        onSave={(data) => {
-                            if (editingSchedule) setSchedules(prev => prev.map(s => s.id === editingSchedule.id ? { ...s, ...data } : s));
-                            else setSchedules(prev => [...prev, { ...data, id: Math.random().toString() }]);
-                            setIsScheduleModalOpen(false);
-                        }}
-                        onDelete={(id) => {
-                            setSchedules(prev => prev.filter(s => s.id !== id));
-                            setIsScheduleModalOpen(false);
-                        }}
-                    />
+                {view !== 'calendar' && (
+                    <motion.div
+                        key={view}
+                        initial={{ x: '100%' }}
+                        animate={{ x: 0 }}
+                        exit={{ x: '100%' }}
+                        transition={{ type: 'spring', stiffness: 320, damping: 32 }}
+                        className="fixed inset-0 z-[60] bg-slate-50 dark:bg-[#0f172a] flex flex-col"
+                    >
+                        {view === 'register' && (
+                            <RegisterPage
+                                selectedDate={selectedDate || new Date()}
+                                editingSchedule={editingSchedule}
+                                editingTodo={editingTodo}
+                                calendars={calendars}
+                                initialTab={registerInitialTab}
+                                onCancel={handleRegisterCancel}
+                                onSaveSchedule={handleSaveSchedule}
+                                onSaveTodo={handleSaveTodo}
+                            />
+                        )}
+                        {view === 'schedule-detail' && editingSchedule && (
+                            <ScheduleDetailPage
+                                schedule={editingSchedule}
+                                calendars={calendars}
+                                onBack={closeOverlayToCalendar}
+                                onEdit={() => setView('register')}
+                                onDelete={handleDeleteSchedule}
+                            />
+                        )}
+                        {view === 'todo-detail' && editingTodo && (
+                            <TodoDetailPage
+                                todo={editingTodo}
+                                onBack={closeOverlayToCalendar}
+                                onEdit={() => setView('register')}
+                                onDelete={handleDeleteTodo}
+                                onToggleComplete={handleToggleTodoComplete}
+                            />
+                        )}
+                    </motion.div>
                 )}
+            </AnimatePresence>
+
+            <AnimatePresence>
                 {isDayScheduleModalOpen && selectedDate && (
                     <DayScheduleModal
                         date={selectedDate}
                         schedules={daySchedules}
+                        todos={dayTodos}
                         calendars={calendars}
                         onClose={() => setIsDayScheduleModalOpen(false)}
                         onSelectSchedule={handleDayScheduleSelect}
-                        onCreateSchedule={() => {
-                            setEditingSchedule(null);
-                            setIsDayScheduleModalOpen(false);
-                            setIsScheduleModalOpen(true);
-                        }}
+                        onSelectTodo={handleDayTodoSelect}
+                        onToggleTodo={handleToggleTodoComplete}
+                        onCreateSchedule={() => handleCreateFromDay('schedule')}
+                        onCreateTodo={() => handleCreateFromDay('todo')}
                     />
                 )}
                 {isAddCalendarModalOpen && (
                     <AddCalendarModal
-                        isOpen={isAddCalendarModalOpen}
                         onClose={() => setIsAddCalendarModalOpen(false)}
-                        onSave={(newCal) => {
-                            setCalendars(prev => [...prev, { ...newCal, id: Math.random().toString(), isVisible: true }]);
+                        onSave={(newCalendar) => {
+                            setCalendars((prev) => [...prev, { ...newCalendar, id: Math.random().toString(), isVisible: true }]);
                             setIsAddCalendarModalOpen(false);
                         }}
                     />
                 )}
             </AnimatePresence>
 
-            {/* FAB for adding schedule */}
-            <ScrollAwareFab
-                onClick={() => {
-                    setSelectedDate(new Date());
-                    setEditingSchedule(null);
-                    setIsScheduleModalOpen(true);
-                }}
-                ariaLabel="일정 추가"
-            >
-                <Plus size={28} />
-            </ScrollAwareFab>
-
-
+            {view === 'calendar' && (
+                <ScrollAwareFab
+                    onClick={() => {
+                        setEditingSchedule(null);
+                        setEditingTodo(null);
+                        setSelectedDate(new Date());
+                        setRegisterInitialTab('schedule');
+                        setView('register');
+                    }}
+                    ariaLabel="일정 추가"
+                >
+                    <Plus size={28} />
+                </ScrollAwareFab>
+            )}
 
             <style>{`
                 .custom-scrollbar::-webkit-scrollbar { width: 4px; }
@@ -670,250 +627,5 @@ const CalendarPage: React.FC<{ onBack: () => void }> = ({ onBack }) => {
         </div>
     );
 };
-
-// --- Modals (ScheduleModal, AddCalendarModal) ---
-const DayScheduleModal: React.FC<{
-    date: Date;
-    schedules: Schedule[];
-    calendars: CalendarCategory[];
-    onClose: () => void;
-    onSelectSchedule: (schedule: Schedule) => void;
-    onCreateSchedule: () => void;
-}> = ({ date, schedules, calendars, onClose, onSelectSchedule, onCreateSchedule }) => {
-    const formatHeader = (value: Date) => {
-        return value.toLocaleDateString('ko-KR', { month: 'long', day: 'numeric', weekday: 'short' });
-    };
-
-    const formatTime = (schedule: Schedule) => {
-        if (schedule.allDay) return '종일';
-        const start = new Date(schedule.start);
-        const end = new Date(schedule.end);
-        const startLabel = start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
-        const endLabel = end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
-        return `${startLabel} - ${endLabel}`;
-    };
-
-    return (
-        <div className="fixed inset-0 z-[110] flex items-center justify-center p-4">
-            <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                onClick={onClose}
-                className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-            />
-            <motion.div
-                initial={{ opacity: 0, scale: 0.96, y: 16 }}
-                animate={{ opacity: 1, scale: 1, y: 0 }}
-                exit={{ opacity: 0, scale: 0.96, y: 16 }}
-                className="relative w-full max-w-md h-[70vh] bg-white dark:bg-slate-900 rounded-3xl shadow-2xl overflow-hidden flex flex-col"
-            >
-                <div className="p-5 border-b border-slate-200 dark:border-white/5 flex items-center">
-                    <div>
-                        <p className="text-xs font-bold text-slate-400 uppercase tracking-wider">일정 목록</p>
-                        <h3 className="text-lg font-black text-slate-900 dark:text-white">{formatHeader(date)}</h3>
-                    </div>
-                </div>
-                <div className="flex-1 overflow-y-auto px-5 py-4 space-y-3 no-scrollbar">
-                    {schedules.map((schedule) => {
-                        const calendar = calendars.find(c => c.id === schedule.calendarId);
-                        return (
-                            <button
-                                key={schedule.id}
-                                onClick={(event) => {
-                                    event.stopPropagation();
-                                    onSelectSchedule(schedule);
-                                }}
-                                className="w-full text-left bg-slate-50 dark:bg-slate-800/40 rounded-2xl p-4 border border-slate-200 dark:border-white/5 hover:border-teal-500/50 transition-colors"
-                            >
-                                <div className="flex items-center gap-3">
-                                    <div className="w-2 h-10 rounded-full" style={{ backgroundColor: calendar?.color }} />
-                                    <div className="flex-1 min-w-0">
-                                        <h4 className="text-sm font-bold text-slate-900 dark:text-white truncate">{schedule.title}</h4>
-                                        <div className="text-[11px] text-slate-500 dark:text-gray-400 mt-1">
-                                            {formatTime(schedule)}
-                                            {schedule.location && ` • ${schedule.location}`}
-                                        </div>
-                                    </div>
-                                </div>
-                            </button>
-                        );
-                    })}
-                </div>
-                <div className="p-4 border-t border-slate-200 dark:border-white/5">
-                    <button
-                        onClick={onCreateSchedule}
-                        className="w-full h-12 border border-slate-300 dark:border-slate-700 rounded-2xl flex items-center justify-center text-slate-300 dark:text-slate-700 hover:text-teal-500 hover:border-teal-400 dark:hover:text-teal-400 transition-colors"
-                    >
-                        <span className="w-8 h-8 rounded-full border border-current flex items-center justify-center">
-                            <Plus size={16} />
-                        </span>
-                    </button>
-                </div>
-            </motion.div>
-        </div>
-    );
-};
-
-const AddCalendarModal: React.FC<{
-    isOpen: boolean;
-    onClose: () => void;
-    onSave: (data: { name: string, color: string }) => void;
-}> = ({ isOpen, onClose, onSave }) => {
-    const [name, setName] = useState('');
-    const [color, setColor] = useState('#10b981');
-    const colors = ['#10b981', '#3b82f6', '#8b5cf6', '#f59e0b', '#ef4444', '#ec4899', '#64748b', '#06b6d4'];
-    return (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
-            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} onClick={onClose} className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
-            <motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.95 }} className="relative w-full max-w-sm bg-white dark:bg-slate-900 rounded-3xl shadow-2xl p-6 overflow-hidden">
-                <div className="flex items-center justify-between mb-6">
-                    <h2 className="text-xl font-black">새 캘린더 만들기</h2>
-                    <button onClick={onClose} className="p-2 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-full transition-colors"><X size={20} /></button>
-                </div>
-                <div className="space-y-6">
-                    <div className="space-y-2">
-                        <label className="text-xs font-bold text-slate-400 uppercase tracking-wider">이름</label>
-                        <input type="text" autoFocus value={name} onChange={e => setName(e.target.value)} placeholder="예: 프로젝트" className="w-full bg-slate-100 dark:bg-slate-800 border-none rounded-xl px-4 py-3 outline-none" />
-                    </div>
-                    <div className="space-y-2">
-                        <label className="text-xs font-bold text-slate-400 uppercase tracking-wider">테마 색상</label>
-                        <div className="grid grid-cols-4 gap-3">
-                            {colors.map(c => (
-                                <button key={c} onClick={() => setColor(c)} className={`w-10 h-10 rounded-full flex items-center justify-center transition-all ${color === c ? 'ring-4 ring-teal-500/20 scale-110' : 'hover:scale-105'}`} style={{ backgroundColor: c }}>
-                                    {color === c && <Check size={20} className="text-white" />}
-                                </button>
-                            ))}
-                        </div>
-                    </div>
-                    <button onClick={() => onSave({ name, color })} disabled={!name} className="w-full py-4 bg-teal-500 text-white rounded-2xl font-black shadow-xl mt-4">캘린더 생성</button>
-                </div>
-            </motion.div>
-        </div>
-    );
-};
-
-const ScheduleModal: React.FC<{
-    isOpen: boolean;
-    onClose: () => void;
-    selectedDate: Date | null;
-    editingSchedule: Schedule | null;
-    calendars: CalendarCategory[];
-    onSave: (data: any) => void;
-    onDelete?: (id: string) => void;
-}> = ({ isOpen, onClose, selectedDate, editingSchedule, calendars, onSave, onDelete }) => {
-    const [title, setTitle] = useState(editingSchedule?.title || '');
-    const [start, setStart] = useState(editingSchedule?.start || (selectedDate ? new Date(selectedDate.getTime() - selectedDate.getTimezoneOffset() * 60000).toISOString().slice(0, 16) : ''));
-    const [end, setEnd] = useState(editingSchedule?.end || (selectedDate ? new Date(selectedDate.getTime() - selectedDate.getTimezoneOffset() * 60000 + 3600000).toISOString().slice(0, 16) : ''));
-    const [allDay, setAllDay] = useState(editingSchedule?.allDay || false);
-    const [calendarId, setCalendarId] = useState(editingSchedule?.calendarId || calendars[0]?.id);
-    const [description, setDescription] = useState(editingSchedule?.description || '');
-    const [location, setLocation] = useState(editingSchedule?.location || '');
-    const [isDeleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-
-    return (
-        <div className="fixed inset-0 z-[100] flex items-end justify-center">
-            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} onClick={onClose} className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
-            <motion.div
-                initial={{ opacity: 0, y: 120 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 120 }}
-                className="relative w-full max-w-md md:max-w-lg bg-white dark:bg-slate-900 rounded-t-3xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh]"
-            >
-                <div className="p-6 border-b border-slate-200 dark:border-white/5 flex items-center justify-between bg-white dark:bg-slate-900">
-                    <div className="w-6" />
-                    <h2 className="text-lg font-black">{editingSchedule ? '일정 수정' : '새 일정 등록'}</h2>
-                    {editingSchedule ? (
-                        <button
-                            onClick={() => setDeleteConfirmOpen(true)}
-                            className="p-2 -mr-2 rounded-full text-slate-500 hover:text-red-500 transition-colors"
-                            aria-label="일정 삭제"
-                        >
-                            <Trash size={18} />
-                        </button>
-                    ) : (
-                        <div className="w-6" />
-                    )}
-                </div>
-                <div className="flex-1 overflow-y-auto">
-                    <div className="p-6 space-y-6 pb-28">
-                        <input type="text" value={title} onChange={e => setTitle(e.target.value)} placeholder="일정 제목" className="w-full bg-transparent text-2xl font-black outline-none" />
-                        <div className="space-y-4">
-                            <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-4"><Clock className="text-slate-400" size={20} /><span className="text-sm font-medium">종일</span></div>
-                                <button onClick={() => setAllDay(!allDay)} className={`w-12 h-6 rounded-full transition-colors relative ${allDay ? 'bg-teal-500' : 'bg-slate-200 dark:bg-slate-800'}`}><div className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-all ${allDay ? 'left-7' : 'left-1'}`} /></button>
-                            </div>
-                            <div className="pl-9 space-y-3">
-                                <div className="flex items-center justify-between"><span className="text-sm text-slate-500">시작</span><input type={allDay ? "date" : "datetime-local"} value={allDay ? start.split('T')[0] : start} onChange={e => setStart(e.target.value)} className="bg-slate-100 dark:bg-slate-800 rounded-lg px-2 py-1 text-sm outline-none" /></div>
-                                <div className="flex items-center justify-between"><span className="text-sm text-slate-500">종료</span><input type={allDay ? "date" : "datetime-local"} value={allDay ? end.split('T')[0] : end} onChange={e => setEnd(e.target.value)} className="bg-slate-100 dark:bg-slate-800 rounded-lg px-2 py-1 text-sm outline-none" /></div>
-                            </div>
-                            <div className="flex flex-wrap gap-2 pl-9">
-                                {calendars.map(cal => (
-                                    <button key={cal.id} onClick={() => setCalendarId(cal.id)} className={`px-3 py-1.5 rounded-full text-xs font-bold ${calendarId === cal.id ? 'bg-slate-900 text-white dark:bg-white dark:text-slate-900' : 'bg-slate-100 dark:bg-slate-800 text-slate-500'}`}>{cal.name}</button>
-                                ))}
-                            </div>
-                            <div className="flex items-center gap-4"><MapPin className="text-slate-400" size={20} /><input type="text" value={location} onChange={e => setLocation(e.target.value)} placeholder="장소 추가" className="flex-1 text-sm outline-none bg-transparent" /></div>
-                            <div className="flex items-start gap-4"><AlignLeft className="text-slate-400" size={20} /><textarea value={description} onChange={e => setDescription(e.target.value)} placeholder="메모 추가..." className="flex-1 text-sm outline-none bg-transparent resize-none h-24" /></div>
-                        </div>
-                    </div>
-                </div>
-                <div className="p-4 border-t border-slate-200 dark:border-white/5 bg-white dark:bg-slate-900 grid grid-cols-2 gap-3">
-                    <button
-                        onClick={() => onSave({ title, start, end, allDay, calendarId, description, location })}
-                        disabled={!title}
-                        className="py-3 rounded-xl font-bold bg-teal-500 text-white disabled:opacity-30"
-                    >
-                        저장
-                    </button>
-                    <button
-                        onClick={onClose}
-                        className="py-3 rounded-xl font-bold bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200"
-                    >
-                        닫기
-                    </button>
-                </div>
-                <AnimatePresence>
-                    {editingSchedule && isDeleteConfirmOpen && (
-                        <div className="absolute inset-0 z-30 flex items-center justify-center">
-                            <motion.div
-                                initial={{ opacity: 0 }}
-                                animate={{ opacity: 1 }}
-                                exit={{ opacity: 0 }}
-                                onClick={() => setDeleteConfirmOpen(false)}
-                                className="absolute inset-0 bg-black/50"
-                            />
-                            <motion.div
-                                initial={{ opacity: 0, scale: 0.95, y: 10 }}
-                                animate={{ opacity: 1, scale: 1, y: 0 }}
-                                exit={{ opacity: 0, scale: 0.95, y: 10 }}
-                                className="relative w-full max-w-xs bg-white dark:bg-slate-900 rounded-2xl shadow-2xl p-5"
-                            >
-                                <h3 className="text-base font-black text-slate-900 dark:text-slate-100">정말 삭제할까요?</h3>
-                                <p className="text-sm text-slate-500 dark:text-slate-400 mt-2">삭제하면 복구할 수 없습니다.</p>
-                                <div className="mt-5 grid grid-cols-2 gap-3">
-                                    <button
-                                        onClick={() => setDeleteConfirmOpen(false)}
-                                        className="py-2.5 rounded-xl font-bold bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200"
-                                    >
-                                        취소
-                                    </button>
-                                    <button
-                                        onClick={() => {
-                                            onDelete?.(editingSchedule.id);
-                                            setDeleteConfirmOpen(false);
-                                        }}
-                                        className="py-2.5 rounded-xl font-bold bg-red-500 text-white"
-                                    >
-                                        삭제
-                                    </button>
-                                </div>
-                            </motion.div>
-                        </div>
-                    )}
-                </AnimatePresence>
-            </motion.div>
-        </div>
-    );
-}
 
 export default CalendarPage;

--- a/components/pages/calendar/AddCalendarModal.tsx
+++ b/components/pages/calendar/AddCalendarModal.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { Check, X } from 'lucide-react';
+
+interface AddCalendarModalProps {
+    onClose: () => void;
+    onSave: (data: { name: string; color: string }) => void;
+}
+
+const AddCalendarModal: React.FC<AddCalendarModalProps> = ({ onClose, onSave }) => {
+    const [name, setName] = useState('');
+    const [color, setColor] = useState('#10b981');
+    const colors = ['#10b981', '#3b82f6', '#8b5cf6', '#f59e0b', '#ef4444', '#ec4899', '#64748b', '#06b6d4'];
+
+    return (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} onClick={onClose} className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+            <motion.div
+                initial={{ opacity: 0, scale: 0.95 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.95 }}
+                className="relative w-full max-w-sm bg-white dark:bg-slate-900 rounded-3xl shadow-2xl p-6"
+            >
+                <div className="flex items-center justify-between mb-6">
+                    <h2 className="text-xl font-black">새 캘린더 만들기</h2>
+                    <button onClick={onClose} className="p-2 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-full transition-colors">
+                        <X size={20} />
+                    </button>
+                </div>
+                <div className="space-y-5">
+                    <div className="space-y-2">
+                        <label className="text-xs font-bold text-slate-400 uppercase tracking-wider">이름</label>
+                        <input
+                            type="text"
+                            autoFocus
+                            value={name}
+                            onChange={(event) => setName(event.target.value)}
+                            placeholder="예: 프로젝트"
+                            className="w-full bg-slate-100 dark:bg-slate-800 rounded-xl px-4 py-3 outline-none text-sm"
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <label className="text-xs font-bold text-slate-400 uppercase tracking-wider">색상</label>
+                        <div className="grid grid-cols-4 gap-3">
+                            {colors.map((item) => (
+                                <button
+                                    key={item}
+                                    onClick={() => setColor(item)}
+                                    className={`w-10 h-10 rounded-full flex items-center justify-center transition-all ${color === item ? 'ring-4 ring-offset-2 ring-offset-white dark:ring-offset-slate-900 scale-110' : 'hover:scale-105'}`}
+                                    style={{ backgroundColor: item, ringColor: item }}
+                                >
+                                    {color === item && <Check size={18} className="text-white" />}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+                    <button
+                        onClick={() => onSave({ name, color })}
+                        disabled={!name}
+                        className="w-full py-3.5 bg-teal-500 text-white rounded-2xl font-black shadow-lg shadow-teal-500/20 disabled:opacity-30 mt-2"
+                    >
+                        캘린더 생성
+                    </button>
+                </div>
+            </motion.div>
+        </div>
+    );
+};
+
+export default AddCalendarModal;

--- a/components/pages/calendar/CustomCalendarView.tsx
+++ b/components/pages/calendar/CustomCalendarView.tsx
@@ -1,0 +1,203 @@
+import React, { useMemo } from 'react';
+import type { CalendarCategory } from '../../calendar/CalendarSidebar';
+import type { Schedule, Todo } from './types';
+import { getDaysInMonth } from './utils';
+
+interface CustomCalendarViewProps {
+    date: Date;
+    schedules: Schedule[];
+    todos: Todo[];
+    calendars: CalendarCategory[];
+    onDateClick: (date: Date) => void;
+    onEventClick: (schedule: Schedule) => void;
+    onTodoClick: (todo: Todo) => void;
+}
+
+const CustomCalendarView: React.FC<CustomCalendarViewProps> = ({
+    date,
+    schedules,
+    todos,
+    calendars,
+    onDateClick,
+    onEventClick,
+    onTodoClick,
+}) => {
+    const year = date.getFullYear();
+    const month = date.getMonth();
+    const days = useMemo(() => getDaysInMonth(year, month), [year, month]);
+    const today = new Date();
+
+    const scheduleLanes = useMemo(() => {
+        const slots: string[][] = Array(42).fill(0).map(() => []);
+        const sortedSchedules = [...schedules]
+            .filter((schedule) => calendars.find((calendar) => calendar.id === schedule.calendarId)?.isVisible)
+            .sort((a, b) => {
+                if (a.allDay !== b.allDay) return a.allDay ? -1 : 1;
+                return (new Date(b.end).getTime() - new Date(b.start).getTime()) -
+                    (new Date(a.end).getTime() - new Date(a.start).getTime());
+            });
+
+        const assigned: Record<string, number> = {};
+
+        sortedSchedules.forEach((schedule) => {
+            const scheduleStart = new Date(schedule.start);
+            scheduleStart.setHours(0, 0, 0, 0);
+            const scheduleEnd = new Date(schedule.end);
+            scheduleEnd.setHours(0, 0, 0, 0);
+
+            let firstIndex = -1;
+            let lastIndex = -1;
+
+            days.forEach((day, index) => {
+                const cellDate = new Date(day.year, day.month, day.day);
+                if (cellDate >= scheduleStart && cellDate <= scheduleEnd) {
+                    if (firstIndex === -1) firstIndex = index;
+                    lastIndex = index;
+                }
+            });
+
+            if (firstIndex === -1) return;
+
+            let lane = 0;
+            while (true) {
+                let clear = true;
+                for (let index = firstIndex; index <= lastIndex; index++) {
+                    if (slots[index][lane]) {
+                        clear = false;
+                        break;
+                    }
+                }
+
+                if (clear) {
+                    for (let index = firstIndex; index <= lastIndex; index++) {
+                        slots[index][lane] = schedule.id;
+                    }
+                    assigned[schedule.id] = lane;
+                    break;
+                }
+
+                lane++;
+            }
+        });
+
+        return assigned;
+    }, [days, schedules, calendars]);
+
+    return (
+        <div className="flex flex-col h-full select-none">
+            <div className="grid grid-cols-7 border-b border-slate-100 dark:border-white/5">
+                {['일', '월', '화', '수', '목', '금', '토'].map((dayName, index) => (
+                    <div key={dayName} className={`text-[15px] text-center font-semibold py-2 tracking-tight ${index === 0 ? 'text-red-400' : index === 6 ? 'text-blue-400' : 'text-slate-400'}`}>
+                        {dayName}
+                    </div>
+                ))}
+            </div>
+            <div className="grid grid-cols-7 flex-1">
+                {days.map((day, index) => {
+                    const cellDate = new Date(day.year, day.month, day.day);
+                    const isToday = today.toDateString() === cellDate.toDateString();
+                    const dayLanes: Array<Schedule | null> = [];
+
+                    schedules.forEach((schedule) => {
+                        const lane = scheduleLanes[schedule.id];
+                        if (lane === undefined) return;
+
+                        const scheduleStart = new Date(schedule.start);
+                        scheduleStart.setHours(0, 0, 0, 0);
+                        const scheduleEnd = new Date(schedule.end);
+                        scheduleEnd.setHours(0, 0, 0, 0);
+
+                        if (cellDate >= scheduleStart && cellDate <= scheduleEnd) {
+                            dayLanes[lane] = schedule;
+                        }
+                    });
+
+                    const cellDateStr = `${day.year}-${String(day.month + 1).padStart(2, '0')}-${String(day.day).padStart(2, '0')}`;
+                    const cellTodos = todos.filter((todo) => todo.date === cellDateStr);
+                    const totalItems = Math.max(dayLanes.filter(Boolean).length, dayLanes.length) + cellTodos.length;
+
+                    return (
+                        <div
+                            key={`${day.year}-${day.month}-${day.day}-${index}`}
+                            onClick={() => onDateClick(cellDate)}
+                            className={`border-r border-b border-slate-50 dark:border-white/5 pt-0.5 pb-1 min-h-0 flex flex-col transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/20 cursor-pointer ${!day.isCurrentMonth ? 'opacity-30' : ''}`}
+                        >
+                            <span className={`text-[13px] font-semibold w-5 h-5 flex items-center justify-center rounded-full ml-auto mb-0.5 mr-1 ${isToday ? 'bg-teal-500 text-white' : 'text-slate-400'}`}>
+                                {day.day}
+                            </span>
+                            <div className="flex flex-col gap-0.5">
+                                {Array.from({ length: Math.min(dayLanes.length, 3) }).map((_, laneIndex) => {
+                                    const schedule = dayLanes[laneIndex];
+                                    if (!schedule) return <div key={laneIndex} className="h-4" />;
+
+                                    const calendar = calendars.find((item) => item.id === schedule.calendarId);
+                                    const scheduleStart = new Date(schedule.start);
+                                    scheduleStart.setHours(0, 0, 0, 0);
+                                    const scheduleEnd = new Date(schedule.end);
+                                    scheduleEnd.setHours(0, 0, 0, 0);
+                                    const isStart = scheduleStart.getTime() === cellDate.getTime();
+                                    const isEnd = scheduleEnd.getTime() === cellDate.getTime();
+                                    const isMultiDay = scheduleStart.getTime() !== scheduleEnd.getTime();
+                                    const isWeekStart = index % 7 === 0;
+
+                                    if (schedule.allDay || isMultiDay) {
+                                        const showTitle = isStart || isWeekStart;
+                                        return (
+                                            <div
+                                                key={schedule.id}
+                                                onClick={(event) => {
+                                                    event.stopPropagation();
+                                                    onEventClick(schedule);
+                                                }}
+                                                className={`h-4 text-[10px] py-0.5 truncate text-white font-medium opacity-90 transition-transform active:scale-95 relative ${!isEnd ? 'w-[calc(100%+1px)] z-10' : 'w-full'} ${isStart ? 'rounded-l-[5px]' : ''} ${isEnd ? 'rounded-r-[5px]' : ''} ${showTitle ? 'px-1.5' : 'px-0'}`}
+                                                style={{ backgroundColor: calendar?.color || '#ccc' }}
+                                            >
+                                                {showTitle && schedule.title}
+                                            </div>
+                                        );
+                                    }
+
+                                    return (
+                                        <div
+                                            key={schedule.id}
+                                            onClick={(event) => {
+                                                event.stopPropagation();
+                                                onEventClick(schedule);
+                                            }}
+                                            className="h-3 flex items-center gap-1 text-[10px] font-medium text-slate-700 dark:text-slate-300 transition-transform active:scale-95"
+                                        >
+                                            <div className="w-0.5 h-3 flex-shrink-0" style={{ backgroundColor: calendar?.color || '#ccc' }} />
+                                            <span className="truncate">{schedule.title}</span>
+                                        </div>
+                                    );
+                                })}
+                                {cellTodos.slice(0, 2).map((todo) => (
+                                    <div
+                                        key={todo.id}
+                                        onClick={(event) => {
+                                            event.stopPropagation();
+                                            onTodoClick(todo);
+                                        }}
+                                        className="h-3 flex items-center gap-0.5 text-[10px] font-medium transition-transform active:scale-95"
+                                    >
+                                        <div className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${todo.completed ? 'bg-violet-300' : 'bg-violet-500'}`} />
+                                        <span className={`truncate ${todo.completed ? 'line-through text-slate-400 dark:text-slate-500' : 'text-slate-700 dark:text-slate-300'}`}>
+                                            {todo.title}
+                                        </span>
+                                    </div>
+                                ))}
+                                {totalItems > 4 && (
+                                    <div className="h-4 text-[9px] font-bold text-slate-400 dark:text-slate-500 flex items-center pl-1">
+                                        +{totalItems - 4}
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};
+
+export default CustomCalendarView;

--- a/components/pages/calendar/DayScheduleModal.tsx
+++ b/components/pages/calendar/DayScheduleModal.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Calendar as CalendarIcon, Check, ChevronRight, Plus, X } from 'lucide-react';
+import type { CalendarCategory } from '../../calendar/CalendarSidebar';
+import type { Schedule, Todo } from './types';
+
+interface DayScheduleModalProps {
+    date: Date;
+    schedules: Schedule[];
+    todos: Todo[];
+    calendars: CalendarCategory[];
+    onClose: () => void;
+    onSelectSchedule: (schedule: Schedule) => void;
+    onSelectTodo: (todo: Todo) => void;
+    onToggleTodo: (id: string) => void;
+    onCreateSchedule: () => void;
+    onCreateTodo: () => void;
+}
+
+const DayScheduleModal: React.FC<DayScheduleModalProps> = ({
+    date,
+    schedules,
+    todos,
+    calendars,
+    onClose,
+    onSelectSchedule,
+    onSelectTodo,
+    onToggleTodo,
+    onCreateSchedule,
+    onCreateTodo,
+}) => {
+    const formatTime = (schedule: Schedule) => {
+        if (schedule.allDay) return '종일';
+        const start = new Date(schedule.start);
+        const end = new Date(schedule.end);
+        return `${start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false })} - ${end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false })}`;
+    };
+
+    return (
+        <div className="fixed inset-0 z-[110] flex items-end sm:items-center justify-center p-0 sm:p-4">
+            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} onClick={onClose} className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+            <motion.div
+                initial={{ opacity: 0, y: 40 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 40 }}
+                className="relative w-full sm:max-w-md h-[65vh] bg-white dark:bg-slate-900 rounded-t-3xl sm:rounded-3xl shadow-2xl overflow-hidden flex flex-col"
+            >
+                <div className="p-5 border-b border-slate-100 dark:border-white/5 flex items-center justify-between">
+                    <div>
+                        <p className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-0.5">일정 & 할 일</p>
+                        <h3 className="text-lg font-black text-slate-900 dark:text-white">
+                            {date.toLocaleDateString('ko-KR', { month: 'long', day: 'numeric', weekday: 'short' })}
+                        </h3>
+                    </div>
+                    <button onClick={onClose} className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-400 transition-colors">
+                        <X size={18} />
+                    </button>
+                </div>
+
+                <div className="flex-1 overflow-y-auto px-4 py-3 space-y-2">
+                    {schedules.length > 0 && (
+                        <>
+                            <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest px-1 pb-1">일정</p>
+                            {schedules.map((schedule) => {
+                                const calendar = calendars.find((item) => item.id === schedule.calendarId);
+                                return (
+                                    <button
+                                        key={schedule.id}
+                                        onClick={() => onSelectSchedule(schedule)}
+                                        className="w-full text-left bg-slate-50 dark:bg-slate-800/50 rounded-2xl p-3.5 hover:bg-slate-100 dark:hover:bg-slate-700/50 transition-colors flex items-center gap-3"
+                                    >
+                                        <div className="w-2 h-10 rounded-full flex-shrink-0" style={{ backgroundColor: calendar?.color }} />
+                                        <div className="flex-1 min-w-0">
+                                            <p className="text-sm font-bold text-slate-900 dark:text-white truncate">{schedule.title}</p>
+                                            <p className="text-xs text-slate-400 mt-0.5">{formatTime(schedule)}{schedule.location && ` · ${schedule.location}`}</p>
+                                        </div>
+                                        <ChevronRight size={14} className="text-slate-300 flex-shrink-0" />
+                                    </button>
+                                );
+                            })}
+                        </>
+                    )}
+                    {todos.length > 0 && (
+                        <>
+                            <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest px-1 pb-1 pt-2">할 일</p>
+                            {todos.map((todo) => (
+                                <div key={todo.id} className="bg-slate-50 dark:bg-slate-800/50 rounded-2xl p-3.5 flex items-center gap-3">
+                                    <button
+                                        onClick={() => onToggleTodo(todo.id)}
+                                        className={`w-5 h-5 rounded-md border-2 flex-shrink-0 flex items-center justify-center transition-colors ${todo.completed ? 'bg-violet-500 border-violet-500' : 'border-slate-300 dark:border-slate-600 hover:border-violet-400'}`}
+                                    >
+                                        {todo.completed && <Check size={11} className="text-white" strokeWidth={3} />}
+                                    </button>
+                                    <button onClick={() => onSelectTodo(todo)} className="flex-1 min-w-0 text-left">
+                                        <p className={`text-sm font-bold truncate ${todo.completed ? 'line-through text-slate-400 dark:text-slate-500' : 'text-slate-900 dark:text-white'}`}>{todo.title}</p>
+                                        <p className="text-xs text-slate-400 mt-0.5">{todo.allDay ? '하루종일' : todo.time}</p>
+                                    </button>
+                                    <ChevronRight size={14} className="text-slate-300 flex-shrink-0" />
+                                </div>
+                            ))}
+                        </>
+                    )}
+                    {schedules.length === 0 && todos.length === 0 && (
+                        <div className="flex flex-col items-center justify-center py-12 text-slate-300 dark:text-slate-600">
+                            <CalendarIcon size={28} className="mb-3" />
+                            <p className="text-sm font-semibold">항목이 없습니다</p>
+                        </div>
+                    )}
+                </div>
+
+                <div className="p-4 border-t border-slate-100 dark:border-white/5 grid grid-cols-2 gap-2">
+                    <button
+                        onClick={onCreateSchedule}
+                        className="h-11 rounded-2xl border border-slate-200 dark:border-slate-700 text-xs font-bold text-slate-500 hover:text-teal-600 hover:border-teal-400 hover:bg-teal-50/50 dark:hover:bg-teal-500/5 transition-colors flex items-center justify-center gap-1.5"
+                    >
+                        <Plus size={14} /> 일정 추가
+                    </button>
+                    <button
+                        onClick={onCreateTodo}
+                        className="h-11 rounded-2xl border border-slate-200 dark:border-slate-700 text-xs font-bold text-slate-500 hover:text-violet-600 hover:border-violet-400 hover:bg-violet-50/50 dark:hover:bg-violet-500/5 transition-colors flex items-center justify-center gap-1.5"
+                    >
+                        <Check size={14} /> 할 일 추가
+                    </button>
+                </div>
+            </motion.div>
+        </div>
+    );
+};
+
+export default DayScheduleModal;

--- a/components/pages/calendar/RegisterPage.tsx
+++ b/components/pages/calendar/RegisterPage.tsx
@@ -1,0 +1,299 @@
+import React, { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { AlignLeft, ChevronDown, ChevronLeft, Clock, MapPin } from 'lucide-react';
+import type { CalendarCategory } from '../../calendar/CalendarSidebar';
+import type { Schedule, Todo } from './types';
+
+interface RegisterPageProps {
+    selectedDate: Date;
+    editingSchedule: Schedule | null;
+    editingTodo: Todo | null;
+    calendars: CalendarCategory[];
+    initialTab: 'schedule' | 'todo';
+    onCancel: () => void;
+    onSaveSchedule: (data: Omit<Schedule, 'id'>) => void;
+    onSaveTodo: (data: Omit<Todo, 'id' | 'completed' | 'createdAt'>) => void;
+}
+
+const RegisterPage: React.FC<RegisterPageProps> = ({
+    selectedDate,
+    editingSchedule,
+    editingTodo,
+    calendars,
+    initialTab,
+    onCancel,
+    onSaveSchedule,
+    onSaveTodo,
+}) => {
+    const isAndroid = typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent);
+    const isEditing = editingSchedule !== null || editingTodo !== null;
+    const fixedTab: 'schedule' | 'todo' | null = editingSchedule ? 'schedule' : editingTodo ? 'todo' : null;
+    const [activeTab, setActiveTab] = useState<'schedule' | 'todo'>(fixedTab || initialTab);
+
+    const defaultDateStr = new Date(selectedDate.getTime() - selectedDate.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+
+    const [title, setTitle] = useState(editingSchedule?.title || '');
+    const [start, setStart] = useState(editingSchedule?.start || defaultDateStr);
+    const [end, setEnd] = useState(editingSchedule?.end || new Date(selectedDate.getTime() - selectedDate.getTimezoneOffset() * 60000 + 3600000).toISOString().slice(0, 16));
+    const [allDay, setAllDay] = useState(editingSchedule?.allDay ?? false);
+    const [calendarId, setCalendarId] = useState(editingSchedule?.calendarId || calendars[0]?.id);
+    const [description, setDescription] = useState(editingSchedule?.description || '');
+    const [location, setLocation] = useState(editingSchedule?.location || '');
+
+    const [todoTitle, setTodoTitle] = useState(editingTodo?.title || '');
+    const [todoDate, setTodoDate] = useState(
+        editingTodo?.date ||
+        new Date(selectedDate.getTime() - selectedDate.getTimezoneOffset() * 60000).toISOString().slice(0, 10)
+    );
+    const [todoAllDay, setTodoAllDay] = useState(editingTodo?.allDay ?? true);
+    const [todoTime, setTodoTime] = useState(editingTodo?.time || '09:00');
+    const [todoMemo, setTodoMemo] = useState(editingTodo?.memo || '');
+
+    const pageTitle = isEditing
+        ? (fixedTab === 'schedule' ? '일정 수정' : '할 일 수정')
+        : (activeTab === 'schedule' ? '새 일정' : '새 할 일');
+
+    const handleSave = () => {
+        if (activeTab === 'schedule') {
+            if (!title) return;
+            onSaveSchedule({ title, start, end, allDay, calendarId, description, location });
+            return;
+        }
+
+        if (!todoTitle) return;
+        onSaveTodo({
+            title: todoTitle,
+            date: todoDate,
+            allDay: todoAllDay,
+            time: todoAllDay ? undefined : todoTime,
+            memo: todoMemo || undefined,
+        });
+    };
+
+    const isValid = activeTab === 'schedule' ? !!title.trim() : !!todoTitle.trim();
+
+    return (
+        <div className="flex flex-col h-full">
+            <div className="flex items-center h-16 px-2 bg-white dark:bg-slate-900 border-b border-slate-100 dark:border-white/5 flex-shrink-0">
+                <button onClick={onCancel} className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors">
+                    <ChevronLeft size={22} className="text-slate-600 dark:text-slate-300" />
+                </button>
+                <h1 className="flex-1 text-center text-base font-black text-slate-900 dark:text-white">{pageTitle}</h1>
+                <div className="w-10" />
+            </div>
+
+            {!isEditing && (
+                <div className="px-4 py-3 bg-white dark:bg-slate-900 border-b border-slate-100 dark:border-white/5 flex-shrink-0">
+                    <div className="flex bg-slate-100 dark:bg-slate-800 rounded-2xl p-1 gap-1">
+                        <button
+                            onClick={() => setActiveTab('schedule')}
+                            className={`flex-1 py-2.5 text-sm font-bold rounded-xl transition-all ${activeTab === 'schedule' ? 'bg-white dark:bg-slate-700 text-slate-900 dark:text-white shadow-sm' : 'text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'}`}
+                        >
+                            일정
+                        </button>
+                        <button
+                            onClick={() => setActiveTab('todo')}
+                            className={`flex-1 py-2.5 text-sm font-bold rounded-xl transition-all ${activeTab === 'todo' ? 'bg-white dark:bg-slate-700 text-slate-900 dark:text-white shadow-sm' : 'text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'}`}
+                        >
+                            할 일
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            <div className="flex-1 overflow-y-auto">
+                <AnimatePresence mode="wait">
+                    {activeTab === 'schedule' ? (
+                        <motion.div key="schedule-form" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.15 }} className="p-4 space-y-3">
+                            <div className="bg-white dark:bg-slate-900 rounded-2xl px-4 py-4">
+                                <input
+                                    type="text"
+                                    value={title}
+                                    onChange={(event) => setTitle(event.target.value)}
+                                    placeholder="제목을 입력하세요"
+                                    className="w-full bg-transparent text-lg font-black outline-none placeholder:text-slate-300 dark:placeholder:text-slate-600 text-slate-900 dark:text-white"
+                                    autoFocus
+                                />
+                            </div>
+
+                            <div className="bg-white dark:bg-slate-900 rounded-2xl px-4 py-3 space-y-3">
+                                <div className="flex items-center justify-between">
+                                    <div className="flex items-center gap-3">
+                                        <Clock size={17} className="text-slate-400" />
+                                        <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">종일</span>
+                                    </div>
+                                    <button
+                                        onClick={() => setAllDay(!allDay)}
+                                        className={`w-11 h-6 rounded-full transition-colors relative flex-shrink-0 ${allDay ? 'bg-teal-500' : 'bg-slate-200 dark:bg-slate-700'}`}
+                                    >
+                                        <div className={`absolute top-1 w-4 h-4 rounded-full bg-white shadow-sm transition-all ${allDay ? 'left-6' : 'left-1'}`} />
+                                    </button>
+                                </div>
+                                <div className="h-px bg-slate-100 dark:bg-white/5" />
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm text-slate-500">시작</span>
+                                    <input
+                                        type={allDay ? 'date' : 'datetime-local'}
+                                        value={allDay ? start.split('T')[0] : start}
+                                        onChange={(event) => setStart(event.target.value)}
+                                        className={`calendar-picker-input ${isAndroid ? 'android-picker-input' : ''} text-sm font-medium bg-slate-100 dark:bg-slate-800 rounded-xl px-3 py-1.5 pr-3 outline-none text-slate-700 dark:text-slate-200`}
+                                    />
+                                </div>
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm text-slate-500">종료</span>
+                                    <input
+                                        type={allDay ? 'date' : 'datetime-local'}
+                                        value={allDay ? end.split('T')[0] : end}
+                                        onChange={(event) => setEnd(event.target.value)}
+                                        className={`calendar-picker-input ${isAndroid ? 'android-picker-input' : ''} text-sm font-medium bg-slate-100 dark:bg-slate-800 rounded-xl px-3 py-1.5 pr-3 outline-none text-slate-700 dark:text-slate-200`}
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="bg-white dark:bg-slate-900 rounded-2xl px-4 py-3 space-y-2.5">
+                                <p className="text-xs font-black text-slate-400 uppercase tracking-wider">캘린더</p>
+                                <div className="relative">
+                                    <select
+                                        value={calendarId}
+                                        onChange={(event) => setCalendarId(event.target.value)}
+                                        className="w-full appearance-none rounded-xl bg-slate-100 dark:bg-slate-800 px-3 py-3 pr-10 text-sm font-semibold text-slate-700 dark:text-slate-200 outline-none"
+                                    >
+                                        {calendars.map((calendar) => (
+                                            <option key={calendar.id} value={calendar.id}>
+                                                {calendar.name}
+                                            </option>
+                                        ))}
+                                    </select>
+                                    <ChevronDown size={16} className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-slate-400" />
+                                </div>
+                            </div>
+
+                            <div className="bg-white dark:bg-slate-900 rounded-2xl px-4 py-3">
+                                <div className="flex items-center gap-3">
+                                    <MapPin size={17} className="text-slate-400 flex-shrink-0" />
+                                    <input
+                                        type="text"
+                                        value={location}
+                                        onChange={(event) => setLocation(event.target.value)}
+                                        placeholder="장소 추가"
+                                        className="flex-1 text-sm outline-none bg-transparent text-slate-700 dark:text-slate-200 placeholder:text-slate-400"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="bg-white dark:bg-slate-900 rounded-2xl px-4 py-3">
+                                <div className="flex items-start gap-3">
+                                    <AlignLeft size={17} className="text-slate-400 flex-shrink-0 mt-0.5" />
+                                    <textarea
+                                        value={description}
+                                        onChange={(event) => setDescription(event.target.value)}
+                                        placeholder="메모 추가"
+                                        className="flex-1 text-sm outline-none bg-transparent text-slate-700 dark:text-slate-200 placeholder:text-slate-400 resize-none h-20 leading-relaxed"
+                                    />
+                                </div>
+                            </div>
+                        </motion.div>
+                    ) : (
+                        <motion.div key="todo-form" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.15 }} className="p-4 space-y-3">
+                            <div className="bg-white dark:bg-slate-900 rounded-2xl px-4 py-4">
+                                <input
+                                    type="text"
+                                    value={todoTitle}
+                                    onChange={(event) => setTodoTitle(event.target.value)}
+                                    placeholder="제목을 입력하세요"
+                                    className="w-full bg-transparent text-lg font-black outline-none placeholder:text-slate-300 dark:placeholder:text-slate-600 text-slate-900 dark:text-white"
+                                    autoFocus={activeTab === 'todo' || editingTodo !== null}
+                                />
+                            </div>
+
+                            <div className="bg-white dark:bg-slate-900 rounded-2xl px-4 py-3 space-y-3">
+                                <div className="flex items-center justify-between">
+                                    <div className="flex items-center gap-3">
+                                        <Clock size={17} className="text-slate-400" />
+                                        <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">하루종일</span>
+                                    </div>
+                                    <button
+                                        onClick={() => setTodoAllDay(!todoAllDay)}
+                                        className={`w-11 h-6 rounded-full transition-colors relative flex-shrink-0 ${todoAllDay ? 'bg-violet-500' : 'bg-slate-200 dark:bg-slate-700'}`}
+                                    >
+                                        <div className={`absolute top-1 w-4 h-4 rounded-full bg-white shadow-sm transition-all ${todoAllDay ? 'left-6' : 'left-1'}`} />
+                                    </button>
+                                </div>
+                                <div className="h-px bg-slate-100 dark:bg-white/5" />
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm text-slate-500">날짜</span>
+                                    <input
+                                        type="date"
+                                        value={todoDate}
+                                        onChange={(event) => setTodoDate(event.target.value)}
+                                        className={`calendar-picker-input ${isAndroid ? 'android-picker-input' : ''} text-sm font-medium bg-slate-100 dark:bg-slate-800 rounded-xl px-3 py-1.5 pr-3 outline-none text-slate-700 dark:text-slate-200`}
+                                    />
+                                </div>
+                                <AnimatePresence>
+                                    {!todoAllDay && (
+                                        <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} className="flex items-center justify-between overflow-hidden">
+                                            <span className="text-sm text-slate-500">시간</span>
+                                            <input
+                                                type="time"
+                                                value={todoTime}
+                                                onChange={(event) => setTodoTime(event.target.value)}
+                                                className={`calendar-picker-input ${isAndroid ? 'android-picker-input' : ''} text-sm font-medium bg-slate-100 dark:bg-slate-800 rounded-xl px-3 py-1.5 pr-3 outline-none text-slate-700 dark:text-slate-200`}
+                                            />
+                                        </motion.div>
+                                    )}
+                                </AnimatePresence>
+                            </div>
+
+                            <div className="bg-white dark:bg-slate-900 rounded-2xl px-4 py-3">
+                                <div className="flex items-start gap-3">
+                                    <AlignLeft size={17} className="text-slate-400 flex-shrink-0 mt-0.5" />
+                                    <textarea
+                                        value={todoMemo}
+                                        onChange={(event) => setTodoMemo(event.target.value)}
+                                        placeholder="메모 추가"
+                                        className="flex-1 text-sm outline-none bg-transparent text-slate-700 dark:text-slate-200 placeholder:text-slate-400 resize-none h-20 leading-relaxed"
+                                    />
+                                </div>
+                            </div>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+            </div>
+
+            <div className="px-4 py-4 bg-white dark:bg-slate-900 border-t border-slate-100 dark:border-white/5 flex gap-3 flex-shrink-0">
+                <button
+                    onClick={onCancel}
+                    className="flex-1 py-3.5 rounded-2xl font-bold text-sm text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 transition-colors hover:bg-slate-200 dark:hover:bg-slate-700"
+                >
+                    취소
+                </button>
+                <button
+                    onClick={handleSave}
+                    disabled={!isValid}
+                    className={`flex-1 py-3.5 rounded-2xl font-bold text-sm text-white transition-all disabled:opacity-30 ${activeTab === 'schedule' ? 'bg-teal-500 shadow-lg shadow-teal-500/20 hover:bg-teal-600' : 'bg-violet-500 shadow-lg shadow-violet-500/20 hover:bg-violet-600'}`}
+                >
+                    저장
+                </button>
+            </div>
+            <style>{`
+                .calendar-picker-input::-webkit-calendar-picker-indicator {
+                    margin-right: 6px;
+                }
+
+                .android-picker-input {
+                    appearance: none;
+                    -webkit-appearance: none;
+                    background-image: none;
+                }
+
+                .android-picker-input::-webkit-calendar-picker-indicator {
+                    opacity: 0;
+                    width: 0;
+                    margin: 0;
+                }
+            `}</style>
+        </div>
+    );
+};
+
+export default RegisterPage;

--- a/components/pages/calendar/ScheduleDetailPage.tsx
+++ b/components/pages/calendar/ScheduleDetailPage.tsx
@@ -1,0 +1,177 @@
+import React, { useState } from 'react';
+import toast from 'react-hot-toast';
+import { AnimatePresence, motion } from 'framer-motion';
+import { AlignLeft, Calendar, ChevronLeft, Clock, MapPin, Share2, Trash, X } from 'lucide-react';
+import type { CalendarCategory } from '../../calendar/CalendarSidebar';
+import type { Schedule } from './types';
+import { formatKoreanDate, formatKoreanTime } from './utils';
+
+interface ScheduleDetailPageProps {
+    schedule: Schedule;
+    calendars: CalendarCategory[];
+    onBack: () => void;
+    onEdit: () => void;
+    onDelete: (id: string) => void;
+}
+
+const ScheduleDetailPage: React.FC<ScheduleDetailPageProps> = ({ schedule, calendars, onBack, onEdit, onDelete }) => {
+    const [isDeleteConfirm, setIsDeleteConfirm] = useState(false);
+    const calendar = calendars.find((item) => item.id === schedule.calendarId);
+    const start = new Date(schedule.start);
+    const end = new Date(schedule.end);
+
+    const scheduleShareText = [
+        `일정: ${schedule.title}`,
+        schedule.allDay
+            ? `일시: ${formatKoreanDate(start)} ~ ${formatKoreanDate(end)}`
+            : `일시: ${formatKoreanDate(start)} ${formatKoreanTime(start)} ~ ${formatKoreanDate(end)} ${formatKoreanTime(end)}`,
+        calendar ? `캘린더: ${calendar.name}` : null,
+        schedule.location ? `장소: ${schedule.location}` : null,
+        schedule.description ? `메모: ${schedule.description}` : null,
+    ].filter(Boolean).join('\n');
+
+    const handleShare = async () => {
+        try {
+            if (navigator.clipboard?.writeText) {
+                await navigator.clipboard.writeText(scheduleShareText);
+            } else {
+                const textarea = document.createElement('textarea');
+                textarea.value = scheduleShareText;
+                textarea.setAttribute('readonly', '');
+                textarea.style.position = 'fixed';
+                textarea.style.top = '0';
+                textarea.style.left = '0';
+                textarea.style.opacity = '0';
+                document.body.appendChild(textarea);
+                textarea.focus();
+                textarea.select();
+
+                const copied = document.execCommand('copy');
+                document.body.removeChild(textarea);
+
+                if (!copied) {
+                    throw new Error('Clipboard copy failed');
+                }
+            }
+
+            toast.success('클립보드에 저장했습니다.', {
+                duration: 1000,
+            });
+        } catch {
+            toast.error('공유를 실행하지 못했습니다.', {
+                duration: 1000,
+            });
+        }
+    };
+
+    return (
+        <div className="flex flex-col h-full">
+            <div className="flex items-center h-16 px-2 bg-white dark:bg-slate-900 border-b border-slate-100 dark:border-white/5 flex-shrink-0">
+                <button onClick={onBack} className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors">
+                    <ChevronLeft size={22} className="text-slate-600 dark:text-slate-300" />
+                </button>
+                <h1 className="flex-1 text-center text-base font-black text-slate-900 dark:text-white">일정 상세</h1>
+                <div className="w-10" />
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-4 space-y-3">
+                <div className="bg-white dark:bg-slate-900 rounded-2xl p-5">
+                    <div className="flex items-start gap-3">
+                        <div className="w-3 h-3 rounded-full mt-1.5 flex-shrink-0" style={{ backgroundColor: calendar?.color || '#ccc' }} />
+                        <div className="flex-1 min-w-0">
+                            <h2 className="text-xl font-black text-slate-900 dark:text-white leading-tight">{schedule.title}</h2>
+                        </div>
+                    </div>
+                    {calendar && (
+                        <>
+                            <div className="h-px bg-slate-100 dark:bg-white/5 my-3" />
+                            <div className="flex items-center gap-3">
+                                <Calendar size={17} className="text-slate-400 flex-shrink-0" />
+                                <p className="text-sm text-slate-700 dark:text-slate-200">{calendar.name}</p>
+                            </div>
+                        </>
+                    )}
+                </div>
+
+                <div className="bg-white dark:bg-slate-900 rounded-2xl p-5">
+                    <div className="flex items-start gap-3">
+                        <Clock size={17} className="text-slate-400 flex-shrink-0 mt-0.5" />
+                        <div className="space-y-1">
+                            {schedule.allDay ? (
+                                <>
+                                    <p className="text-sm font-semibold text-slate-800 dark:text-white">{formatKoreanDate(start)}</p>
+                                    {start.toDateString() !== end.toDateString() && (
+                                        <p className="text-xs text-slate-400">~ {formatKoreanDate(end)}</p>
+                                    )}
+                                    <p className="text-xs text-slate-400 mt-1">하루종일</p>
+                                </>
+                            ) : (
+                                <>
+                                    <p className="text-sm font-semibold text-slate-800 dark:text-white">{formatKoreanDate(start)}</p>
+                                    <p className="text-xs text-slate-400">{formatKoreanTime(start)} ~ {formatKoreanTime(end)}</p>
+                                </>
+                            )}
+                        </div>
+                    </div>
+                    {schedule.location && (
+                        <>
+                            <div className="h-px bg-slate-100 dark:bg-white/5 my-3" />
+                            <div className="flex items-center gap-3">
+                                <MapPin size={17} className="text-slate-400 flex-shrink-0" />
+                                <p className="text-sm text-slate-700 dark:text-slate-200">{schedule.location}</p>
+                            </div>
+                        </>
+                    )}
+                </div>
+
+                {schedule.description && (
+                    <div className="bg-white dark:bg-slate-900 rounded-2xl p-5">
+                        <div className="flex items-start gap-3">
+                            <AlignLeft size={17} className="text-slate-400 flex-shrink-0 mt-0.5" />
+                            <p className="text-sm text-slate-700 dark:text-slate-200 leading-relaxed whitespace-pre-wrap">{schedule.description}</p>
+                        </div>
+                    </div>
+                )}
+            </div>
+
+            <div className="px-4 py-4 bg-white dark:bg-slate-900 border-t border-slate-100 dark:border-white/5 flex-shrink-0">
+                <div className="grid grid-cols-4 gap-2">
+                    <button onClick={handleShare} className="py-3.5 rounded-2xl font-bold text-xs flex flex-col items-center gap-1.5 bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
+                        <Share2 size={16} />
+                        공유
+                    </button>
+                    <button onClick={onEdit} className="py-3.5 rounded-2xl font-bold text-xs flex flex-col items-center gap-1.5 bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
+                        <AlignLeft size={16} />
+                        편집
+                    </button>
+                    <button onClick={() => setIsDeleteConfirm(true)} className="py-3.5 rounded-2xl font-bold text-xs flex flex-col items-center gap-1.5 bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
+                        <Trash size={16} />
+                        삭제
+                    </button>
+                    <button onClick={onBack} className="py-3.5 rounded-2xl font-bold text-xs flex flex-col items-center gap-1.5 bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
+                        <X size={16} />
+                        닫기
+                    </button>
+                </div>
+            </div>
+
+            <AnimatePresence>
+                {isDeleteConfirm && (
+                    <div className="absolute inset-0 z-30 flex items-center justify-center p-6">
+                        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} onClick={() => setIsDeleteConfirm(false)} className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
+                        <motion.div initial={{ opacity: 0, scale: 0.95, y: 10 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.95 }} className="relative w-full max-w-xs bg-white dark:bg-slate-900 rounded-2xl shadow-2xl p-5">
+                            <h3 className="font-black text-slate-900 dark:text-white">일정을 삭제할까요?</h3>
+                            <p className="text-sm text-slate-400 mt-2">삭제하면 복구할 수 없습니다.</p>
+                            <div className="grid grid-cols-2 gap-3 mt-5">
+                                <button onClick={() => setIsDeleteConfirm(false)} className="py-2.5 rounded-xl font-bold bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200 text-sm">취소</button>
+                                <button onClick={() => onDelete(schedule.id)} className="py-2.5 rounded-xl font-bold bg-red-500 text-white text-sm">삭제</button>
+                            </div>
+                        </motion.div>
+                    </div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+};
+
+export default ScheduleDetailPage;

--- a/components/pages/calendar/TodoDetailPage.tsx
+++ b/components/pages/calendar/TodoDetailPage.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { AlignLeft, Check, ChevronLeft, Clock, Trash, X } from 'lucide-react';
+import type { Todo } from './types';
+import { formatKoreanDate } from './utils';
+
+interface TodoDetailPageProps {
+    todo: Todo;
+    onBack: () => void;
+    onEdit: () => void;
+    onDelete: (id: string) => void;
+    onToggleComplete: (id: string) => void;
+}
+
+const TodoDetailPage: React.FC<TodoDetailPageProps> = ({ todo, onBack, onEdit, onDelete, onToggleComplete }) => {
+    const [isDeleteConfirm, setIsDeleteConfirm] = useState(false);
+    const todoDate = new Date(todo.date + 'T00:00:00');
+    const createdAt = new Date(todo.createdAt);
+
+    return (
+        <div className="flex flex-col h-full">
+            <div className="flex items-center h-16 px-2 bg-white dark:bg-slate-900 border-b border-slate-100 dark:border-white/5 flex-shrink-0">
+                <button onClick={onBack} className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors">
+                    <ChevronLeft size={22} className="text-slate-600 dark:text-slate-300" />
+                </button>
+                <h1 className="flex-1 text-center text-base font-black text-slate-900 dark:text-white">할 일 상세</h1>
+                <div className="w-10" />
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-4 space-y-3">
+                <div className="bg-white dark:bg-slate-900 rounded-2xl p-5">
+                    <div className="flex items-start gap-3">
+                        <button
+                            onClick={() => onToggleComplete(todo.id)}
+                            className={`w-6 h-6 rounded-lg border-2 flex-shrink-0 flex items-center justify-center transition-colors mt-0.5 ${todo.completed ? 'bg-violet-500 border-violet-500' : 'border-slate-300 dark:border-slate-600 hover:border-violet-400'}`}
+                        >
+                            {todo.completed && <Check size={13} className="text-white" strokeWidth={3} />}
+                        </button>
+                        <div className="flex-1 min-w-0">
+                            <h2 className={`text-xl font-black leading-tight ${todo.completed ? 'line-through text-slate-300 dark:text-slate-600' : 'text-slate-900 dark:text-white'}`}>
+                                {todo.title}
+                            </h2>
+                            {todo.completed && (
+                                <span className="inline-block mt-2 px-2.5 py-0.5 rounded-lg text-xs font-bold bg-violet-50 dark:bg-violet-500/10 text-violet-500">
+                                    완료됨
+                                </span>
+                            )}
+                        </div>
+                    </div>
+                </div>
+
+                <div className="bg-white dark:bg-slate-900 rounded-2xl p-5">
+                    <div className="flex items-center gap-3">
+                        <Clock size={17} className="text-slate-400 flex-shrink-0" />
+                        <div>
+                            <p className="text-sm font-semibold text-slate-800 dark:text-white">{formatKoreanDate(todoDate)}</p>
+                            <p className="text-xs text-slate-400 mt-0.5">{todo.allDay ? '하루종일' : todo.time}</p>
+                        </div>
+                    </div>
+                </div>
+
+                {todo.memo && (
+                    <div className="bg-white dark:bg-slate-900 rounded-2xl p-5">
+                        <div className="flex items-start gap-3">
+                            <AlignLeft size={17} className="text-slate-400 flex-shrink-0 mt-0.5" />
+                            <p className="text-sm text-slate-700 dark:text-slate-200 leading-relaxed whitespace-pre-wrap">{todo.memo}</p>
+                        </div>
+                    </div>
+                )}
+
+                <div className="px-1">
+                    <p className="text-xs text-slate-300 dark:text-slate-600">
+                        등록 · {createdAt.toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })}
+                    </p>
+                </div>
+            </div>
+
+            <div className="px-4 py-4 bg-white dark:bg-slate-900 border-t border-slate-100 dark:border-white/5 flex-shrink-0">
+                <div className="grid grid-cols-4 gap-2">
+                    <button onClick={() => onToggleComplete(todo.id)} className="py-3.5 rounded-2xl font-bold text-xs flex flex-col items-center gap-1.5 bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
+                        <Check size={16} strokeWidth={3} />
+                        {todo.completed ? '취소' : '완료'}
+                    </button>
+                    <button onClick={onEdit} className="py-3.5 rounded-2xl font-bold text-xs flex flex-col items-center gap-1.5 bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
+                        <AlignLeft size={16} />
+                        편집
+                    </button>
+                    <button onClick={() => setIsDeleteConfirm(true)} className="py-3.5 rounded-2xl font-bold text-xs flex flex-col items-center gap-1.5 bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
+                        <Trash size={16} />
+                        삭제
+                    </button>
+                    <button onClick={onBack} className="py-3.5 rounded-2xl font-bold text-xs flex flex-col items-center gap-1.5 bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors">
+                        <X size={16} />
+                        닫기
+                    </button>
+                </div>
+            </div>
+
+            <AnimatePresence>
+                {isDeleteConfirm && (
+                    <div className="absolute inset-0 z-30 flex items-center justify-center p-6">
+                        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} onClick={() => setIsDeleteConfirm(false)} className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
+                        <motion.div initial={{ opacity: 0, scale: 0.95, y: 10 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.95 }} className="relative w-full max-w-xs bg-white dark:bg-slate-900 rounded-2xl shadow-2xl p-5">
+                            <h3 className="font-black text-slate-900 dark:text-white">할 일을 삭제할까요?</h3>
+                            <p className="text-sm text-slate-400 mt-2">삭제하면 복구할 수 없습니다.</p>
+                            <div className="grid grid-cols-2 gap-3 mt-5">
+                                <button onClick={() => setIsDeleteConfirm(false)} className="py-2.5 rounded-xl font-bold bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200 text-sm">취소</button>
+                                <button onClick={() => onDelete(todo.id)} className="py-2.5 rounded-xl font-bold bg-red-500 text-white text-sm">삭제</button>
+                            </div>
+                        </motion.div>
+                    </div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+};
+
+export default TodoDetailPage;

--- a/components/pages/calendar/types.ts
+++ b/components/pages/calendar/types.ts
@@ -1,0 +1,23 @@
+export type AppView = 'calendar' | 'register' | 'schedule-detail' | 'todo-detail';
+
+export interface Schedule {
+    id: string;
+    title: string;
+    start: string;
+    end: string;
+    allDay: boolean;
+    calendarId: string;
+    description?: string;
+    location?: string;
+}
+
+export interface Todo {
+    id: string;
+    title: string;
+    date: string;
+    time?: string;
+    allDay: boolean;
+    completed: boolean;
+    memo?: string;
+    createdAt: string;
+}

--- a/components/pages/calendar/utils.ts
+++ b/components/pages/calendar/utils.ts
@@ -1,0 +1,33 @@
+export const getDaysInMonth = (year: number, month: number) => {
+    const date = new Date(year, month, 1);
+    const days = [];
+    const firstDay = date.getDay();
+    const prevMonthLastDay = new Date(year, month, 0).getDate();
+
+    for (let i = firstDay - 1; i >= 0; i--) {
+        days.push({ day: prevMonthLastDay - i, month: month - 1, year, isCurrentMonth: false });
+    }
+
+    const lastDay = new Date(year, month + 1, 0).getDate();
+    for (let i = 1; i <= lastDay; i++) {
+        days.push({ day: i, month, year, isCurrentMonth: true });
+    }
+
+    const remaining = 42 - days.length;
+    for (let i = 1; i <= remaining; i++) {
+        days.push({ day: i, month: month + 1, year, isCurrentMonth: false });
+    }
+
+    return days;
+};
+
+export const formatMonthYear = (date: Date) => `${date.getFullYear()}년 ${date.getMonth() + 1}월`;
+
+export const toLocalDateStr = (date: Date) =>
+    `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+
+export const formatKoreanDate = (date: Date) =>
+    date.toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric', weekday: 'short' });
+
+export const formatKoreanTime = (date: Date) =>
+    date.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "lucide-react": "^0.562.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
+        "react-hot-toast": "^2.6.0",
         "react-router-dom": "^7.12.0"
       },
       "devDependencies": {
@@ -1297,6 +1298,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1435,6 +1442,15 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/js-tokens": {
@@ -1603,6 +1619,23 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^0.562.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 요약
- 캘린더에 할 일 등록, 상세 조회, 완료 처리 흐름을 추가했습니다
- 일정 페이지를 월간 캘린더 중심 멀티뷰 구조로 리팩토링했습니다
- 상세 화면 공유 토스트와 날짜별 모달, 커스텀 월간 뷰를 도입했습니다

## 주요 변경
- `CalendarPage`를 `calendar / register / schedule-detail / todo-detail` 뷰 구조로 재구성
- 일정과 할 일을 함께 등록할 수 있는 `RegisterPage` 추가
- 할 일 상세 페이지 및 완료 토글/수정/삭제 흐름 추가
- 날짜 클릭 시 일정/할 일을 함께 보여주는 `DayScheduleModal` 추가
- 월간 캘린더 렌더링을 `CustomCalendarView`로 분리하고 멀티데이 일정 lane 배치 적용
- 캘린더 전용 타입/유틸 분리 (`types.ts`, `utils.ts`)
- 일정 상세 공유 기능을 위해 `react-hot-toast` 추가 및 전역 토스트 UI 구성

## 테스트
- 별도 자동 테스트는 실행하지 않았습니다

## 관련 이슈
- Closes #30
- Closes #31