### PR TITLE
feat: 일기 API 연동 준비 및 사진/회고 필드 리뉴얼

### DIFF
--- a/api/auth.ts
+++ b/api/auth.ts
@@ -1,77 +1,37 @@
 import { env } from '../config/env';
+import { apiRequest, ApiError } from './httpClient';
 
 const AUTH_API_PREFIX = '/auth/v1';
-
-export interface ApiErrorData {
-  error_code: string;
-  message: string;
-  details: { field: string; message: string }[] | null;
-}
-
-export interface ApiErrorResponse {
-  data: ApiErrorData;
-}
 
 export interface SignupResponseData {
   id: string;
   username: string;
-  created_at: string;
+  createdAt: string;
 }
 
-export class ApiError extends Error {
-  constructor(
-    public readonly errorCode: string,
-    message: string,
-  ) {
-    super(message);
-  }
-}
-
-async function parseErrorResponse(res: Response): Promise<ApiError> {
-  try {
-    const body: ApiErrorResponse = await res.json();
-    return new ApiError(body.data.error_code, body.data.message);
-  } catch {
-    return new ApiError('UNKNOWN', '요청에 실패했습니다.');
-  }
-}
+export { ApiError };
 
 function authUrl(path: string): string {
   return `${env.apiHost}${AUTH_API_PREFIX}${path}`;
 }
 
-async function fetchAuth(path: string, init?: RequestInit): Promise<Response> {
-  const res = await fetch(authUrl(path), {
-    credentials: 'include',
-    ...init,
-  });
-
-  if (!res.ok) {
-    throw await parseErrorResponse(res);
-  }
-
-  return res;
-}
-
-export async function login(login_id: string, password: string): Promise<void> {
-  await fetchAuth('/login', {
+export async function login(loginId: string, password: string): Promise<void> {
+  await apiRequest(authUrl('/login'), {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ login_id, password }),
+    json: { loginId, password },
   });
 }
 
 export async function sendEmailVerification(email: string): Promise<void> {
-  await fetchAuth('/signup/email/verify', {
+  await apiRequest(authUrl('/signup/email/verify'), {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email }),
+    json: { email },
   });
 }
 
 export async function verifyEmailCode(email: string, token: string): Promise<void> {
   const params = new URLSearchParams({ email, token });
-  await fetchAuth(`/signup/email/verify?${params.toString()}`, {
+  await apiRequest(authUrl(`/signup/email/verify?${params.toString()}`), {
     method: 'GET',
   });
 }
@@ -81,12 +41,8 @@ export async function signup(
   nickname: string,
   password: string,
 ): Promise<SignupResponseData> {
-  const res = await fetchAuth('/signup', {
+  return apiRequest<SignupResponseData>(authUrl('/signup'), {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, nickname, password }),
+    json: { email, nickname, password },
   });
-
-  const body: { data: SignupResponseData } = await res.json();
-  return body.data;
 }

--- a/api/caseConverter.ts
+++ b/api/caseConverter.ts
@@ -1,0 +1,39 @@
+function camelToSnake(key: string): string {
+  return key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+}
+
+function snakeToCamel(key: string): string {
+  return key.replace(/_([a-zA-Z0-9])/g, (_, char) => char.toUpperCase());
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date);
+}
+
+export function toSnakeCase<T>(value: T): unknown {
+  if (Array.isArray(value)) {
+    return value.map(toSnakeCase);
+  }
+
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, val]) => [camelToSnake(key), toSnakeCase(val)]),
+    );
+  }
+
+  return value;
+}
+
+export function toCamelCase<T>(value: unknown): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => toCamelCase(item)) as unknown as T;
+  }
+
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, val]) => [snakeToCamel(key), toCamelCase(val)]),
+    ) as T;
+  }
+
+  return value as T;
+}

--- a/api/diary.ts
+++ b/api/diary.ts
@@ -1,51 +1,32 @@
 import { env } from '../config/env';
-import { Diary, DiaryCreateRequest, DiaryUpdateRequest } from '../types';
+import { CreateDiaryRequest, CreateDiaryResponse } from '../types';
+import { apiRequest, ApiError } from './httpClient';
 
-async function fetchDiary(path: string, init?: RequestInit): Promise<Response> {
-  const res = await fetch(`${env.apiHost}/diary${path}`, {
-    credentials: 'include',
-    ...init,
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    const message = (body as any)?.data?.message ?? (body as any)?.message ?? '요청에 실패했습니다.';
-    throw new Error(message);
-  }
-  return res;
+const DIARY_API_PREFIX = '/v1/diaries';
+
+function diaryUrl(path: string): string {
+  return `${env.apiHost}${DIARY_API_PREFIX}${path}`;
 }
 
-export async function getDiaries(): Promise<Diary[]> {
-  const res = await fetchDiary('', { method: 'GET' });
-  const body: { data: Diary[] } = await res.json();
-  return body.data;
-}
-
-export async function createDiary(payload: DiaryCreateRequest): Promise<Diary> {
-  const res = await fetchDiary('', {
+/**
+ * 일기 작성
+ * POST /v1/diaries
+ */
+export async function createDiary(payload: CreateDiaryRequest): Promise<CreateDiaryResponse> {
+  return apiRequest<CreateDiaryResponse>(diaryUrl(''), {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
+    json: payload,
   });
-  const body: { data: Diary } = await res.json();
-  return body.data;
 }
 
-export async function getDiaryById(id: string): Promise<Diary> {
-  const res = await fetchDiary(`/${id}`, { method: 'GET' });
-  const body: { data: Diary } = await res.json();
-  return body.data;
-}
-
-export async function updateDiary(id: string, payload: DiaryUpdateRequest): Promise<Diary> {
-  const res = await fetchDiary(`/${id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-  const body: { data: Diary } = await res.json();
-  return body.data;
-}
-
+/**
+ * 일기 삭제
+ * DELETE /v1/diaries/{id}
+ */
 export async function deleteDiary(id: string): Promise<void> {
-  await fetchDiary(`/${id}`, { method: 'DELETE' });
+  await apiRequest(diaryUrl(`/${id}`), {
+    method: 'DELETE',
+  });
 }
+
+export { ApiError };

--- a/api/diaryMock.ts
+++ b/api/diaryMock.ts
@@ -1,4 +1,4 @@
-import { Diary, DiaryCreateRequest, DiaryUpdateRequest, EmotionKey, WeatherKey } from '../types';
+import { Diary, DiaryUpdateRequest, EmotionKey, WeatherKey } from '../types';
 
 // 인메모리 목업 저장소
 let mockDiaries: Diary[] = [
@@ -11,8 +11,13 @@ let mockDiaries: Diary[] = [
     energy: 4,
     satisfaction: 5,
     keywords: ['친구', '카페', '휴식'],
-    goodThings: ['오랜 친구와 시간을 보냄', '산책 30분'],
-    badThings: ['저녁을 너무 많이 먹음'],
+    achievement: ['오랜 친구와 시간을 보냄', '산책 30분'],
+    regret: ['저녁을 너무 많이 먹음'],
+    images: [
+      'https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=800&h=400&fit=crop',
+      'https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=800&h=400&fit=crop',
+      'https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=800&h=400&fit=crop',
+    ],
     createdAt: '2026-04-04T10:00:00Z',
     updatedAt: '2026-04-04T10:00:00Z',
   },
@@ -25,8 +30,12 @@ let mockDiaries: Diary[] = [
     energy: 2,
     satisfaction: 3,
     keywords: ['회의', '야근'],
-    goodThings: ['프로젝트 마감 성공'],
-    badThings: ['수면 부족', '운동 못함'],
+    achievement: ['프로젝트 마감 성공'],
+    regret: ['수면 부족', '운동 못함'],
+    images: [
+      'https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?w=800&h=400&fit=crop',
+      'https://images.unsplash.com/photo-1497366216548-3d5c0e71c00e?w=800&h=400&fit=crop',
+    ],
     createdAt: '2026-04-03T22:30:00Z',
     updatedAt: '2026-04-03T22:30:00Z',
   },
@@ -39,8 +48,11 @@ let mockDiaries: Diary[] = [
     energy: 5,
     satisfaction: 4,
     keywords: ['회의', '공부'],
-    goodThings: ['팀원들과 좋은 출발'],
-    badThings: [],
+    achievement: ['팀원들과 좋은 출발'],
+    regret: [],
+    images: [
+      'https://images.unsplash.com/photo-1522071820081-009f0129c71c?w=800&h=400&fit=crop',
+    ],
     createdAt: '2026-04-01T14:00:00Z',
     updatedAt: '2026-04-01T14:00:00Z',
   },
@@ -53,8 +65,12 @@ let mockDiaries: Diary[] = [
     energy: 2,
     satisfaction: 2,
     keywords: ['휴식'],
-    goodThings: ['영화 두 편 봄'],
-    badThings: ['하루 종일 집에만 있음', '생산성 제로'],
+    achievement: ['영화 두 편 봄'],
+    regret: ['하루 종일 집에만 있음', '생산성 제로'],
+    images: [
+      'https://images.unsplash.com/photo-1515694346937-94d136942782?w=800&h=400&fit=crop',
+      'https://images.unsplash.com/photo-1501691223387-dd0500403074?w=800&h=400&fit=crop',
+    ],
     createdAt: '2026-03-30T18:00:00Z',
     updatedAt: '2026-03-30T18:00:00Z',
   },
@@ -62,13 +78,14 @@ let mockDiaries: Diary[] = [
     id: '5',
     date: '2026-03-28',
     emotion: 'neutral' as EmotionKey,
-    weather: 'windy' as WeatherKey,
+    weather: 'typhoon' as WeatherKey,
     content: '',
     energy: 3,
     satisfaction: null,
     keywords: [],
-    goodThings: [],
-    badThings: [],
+    achievement: [],
+    regret: [],
+    images: [],
     createdAt: '2026-03-28T09:00:00Z',
     updatedAt: '2026-03-28T09:00:00Z',
   },
@@ -89,11 +106,20 @@ export function getDiaryById(id: string): Promise<Diary> {
   return Promise.resolve({ ...diary });
 }
 
-export function createDiary(payload: DiaryCreateRequest): Promise<Diary> {
+export function createDiary(payload: DiaryUpdateRequest): Promise<Diary> {
   const now = new Date().toISOString();
   const newDiary: Diary = {
     id: String(nextId++),
-    ...payload,
+    date: payload.date ?? new Date().toISOString().slice(0, 10),
+    emotion: payload.emotion ?? null,
+    weather: payload.weather ?? null,
+    content: payload.content ?? '',
+    energy: payload.energy ?? null,
+    satisfaction: payload.satisfaction ?? null,
+    keywords: payload.keywords ?? [],
+    achievement: payload.achievement ?? [],
+    regret: payload.regret ?? [],
+    images: payload.images ?? [],
     createdAt: now,
     updatedAt: now,
   };

--- a/api/httpClient.ts
+++ b/api/httpClient.ts
@@ -1,0 +1,59 @@
+import { toCamelCase, toSnakeCase } from './caseConverter';
+
+export interface ApiErrorData {
+  errorCode: string;
+  message: string;
+  details: { field: string; message: string }[] | null;
+}
+
+export interface ApiErrorResponse {
+  data: ApiErrorData;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly errorCode: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export async function parseErrorResponse(res: Response): Promise<ApiError> {
+  try {
+    const body = toCamelCase<ApiErrorResponse>(await res.json());
+    return new ApiError(body.data.errorCode, body.data.message);
+  } catch {
+    return new ApiError('UNKNOWN', '요청에 실패했습니다.');
+  }
+}
+
+export interface ApiRequestInit extends Omit<RequestInit, 'body'> {
+  json?: unknown;
+}
+
+export async function apiRequest<TResponse = void>(
+  url: string,
+  init: ApiRequestInit = {},
+): Promise<TResponse> {
+  const { json, headers, ...rest } = init;
+
+  const res = await fetch(url, {
+    credentials: 'include',
+    ...rest,
+    headers: json !== undefined ? { 'Content-Type': 'application/json', ...headers } : headers,
+    body: json !== undefined ? JSON.stringify(toSnakeCase(json)) : undefined,
+  });
+
+  if (!res.ok) {
+    throw await parseErrorResponse(res);
+  }
+
+  const text = await res.text();
+  if (!text) {
+    return undefined as TResponse;
+  }
+
+  const body = toCamelCase<{ data: TResponse }>(JSON.parse(text));
+  return body.data;
+}

--- a/api/signup.ts
+++ b/api/signup.ts
@@ -6,8 +6,6 @@ export {
   verifyEmailCode,
 } from './auth';
 
-export type {
-  ApiErrorData,
-  ApiErrorResponse,
-  SignupResponseData,
-} from './auth';
+export type { SignupResponseData } from './auth';
+
+export type { ApiErrorData, ApiErrorResponse } from './httpClient';

--- a/components/diary/DiaryCard.tsx
+++ b/components/diary/DiaryCard.tsx
@@ -68,13 +68,40 @@ const DiaryCard: React.FC<DiaryCardProps> = ({ diary, onClick, index = 0 }) => {
         </div>
       </div>
 
-      {diary.content ? (
-        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200 line-clamp-2">
-          {diary.content}
-        </p>
-      ) : (
-        <p className="text-sm text-slate-400 dark:text-slate-500 italic">내용 없음</p>
-      )}
+      <div className="flex gap-3">
+        {diary.images.length === 1 && (
+          <div className="flex-shrink-0 w-14 h-14 rounded-xl overflow-hidden">
+            <img src={diary.images[0]} alt="" className="w-full h-full object-cover" />
+          </div>
+        )}
+        {diary.images.length === 2 && (
+          <div className="flex-shrink-0 w-14 h-14 rounded-xl overflow-hidden flex">
+            <img
+              src={diary.images[0]}
+              alt=""
+              className="w-7 h-14 object-cover border-r border-slate-200 dark:border-slate-600"
+            />
+            <img src={diary.images[1]} alt="" className="w-7 h-14 object-cover" />
+          </div>
+        )}
+        {diary.images.length >= 3 && (
+          <div className="relative flex-shrink-0 w-14 h-14 rounded-xl overflow-hidden">
+            <img src={diary.images[0]} alt="" className="w-full h-full object-cover" />
+            <span className="absolute bottom-0 right-0 bg-black/60 text-white text-[10px] font-bold px-1 leading-4 rounded-tl-md">
+              +{diary.images.length - 1}
+            </span>
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          {diary.content ? (
+            <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200 line-clamp-2">
+              {diary.content}
+            </p>
+          ) : (
+            <p className="text-sm text-slate-400 dark:text-slate-500 italic">내용 없음</p>
+          )}
+        </div>
+      </div>
 
       {diary.keywords.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-2">

--- a/components/diary/KeywordPicker.tsx
+++ b/components/diary/KeywordPicker.tsx
@@ -3,8 +3,6 @@ import { X } from 'lucide-react';
 
 const MAX_KEYWORDS = 5;
 
-const PRESET_KEYWORDS = ['운동', '회의', '공부', '여행', '휴식', '독서', '요리', '쇼핑', '친구', '가족'];
-
 interface KeywordPickerProps {
   value: string[];
   onChange: (keywords: string[]) => void;
@@ -13,16 +11,7 @@ interface KeywordPickerProps {
 const KeywordPicker: React.FC<KeywordPickerProps> = ({ value, onChange }) => {
   const [input, setInput] = useState('');
 
-  function toggle(keyword: string) {
-    if (value.includes(keyword)) {
-      onChange(value.filter((k) => k !== keyword));
-    } else {
-      if (value.length >= MAX_KEYWORDS) return;
-      onChange([...value, keyword]);
-    }
-  }
-
-  function addCustom() {
+  function addKeyword() {
     const trimmed = input.trim().replace(/[#\s]+/g, '');
     if (!trimmed || value.includes(trimmed) || value.length >= MAX_KEYWORDS) {
       setInput('');
@@ -35,75 +24,52 @@ const KeywordPicker: React.FC<KeywordPickerProps> = ({ value, onChange }) => {
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter') {
       e.preventDefault();
-      addCustom();
+      addKeyword();
     }
+  }
+
+  function removeKeyword(keyword: string) {
+    onChange(value.filter((k) => k !== keyword));
   }
 
   return (
     <div className="space-y-3">
-      {/* 프리셋 */}
-      <div className="grid grid-cols-5 gap-1.5 sm:gap-2">
-        {PRESET_KEYWORDS.map((keyword) => {
-          const selected = value.includes(keyword);
-          const disabled = !selected && value.length >= MAX_KEYWORDS;
-          return (
-            <button
+      {/* 키워드 라벨 */}
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {value.map((keyword) => (
+            <span
               key={keyword}
-              type="button"
-              onClick={() => toggle(keyword)}
-              disabled={disabled}
-              className={`min-w-0 rounded-full px-1.5 py-1.5 text-center text-xs sm:text-sm font-medium transition-colors ${
-                selected
-                  ? 'bg-teal-500 text-white'
-                  : disabled
-                  ? 'bg-slate-100 dark:bg-slate-800 text-slate-300 dark:text-slate-600 cursor-not-allowed'
-                  : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700'
-              }`}
+              className="flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300"
             >
               #{keyword}
-            </button>
-          );
-        })}
-      </div>
-
-      {/* 선택된 커스텀 태그 (프리셋에 없는 것) */}
-      {value.filter((k) => !PRESET_KEYWORDS.includes(k)).length > 0 && (
-        <div className="flex flex-wrap gap-2">
-          {value
-            .filter((k) => !PRESET_KEYWORDS.includes(k))
-            .map((keyword) => (
-              <span
-                key={keyword}
-                className="flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium bg-teal-500 text-white"
+              <button
+                type="button"
+                onClick={() => removeKeyword(keyword)}
+                className="hover:opacity-70 transition-opacity"
+                aria-label={`${keyword} 제거`}
               >
-                #{keyword}
-                <button
-                  type="button"
-                  onClick={() => onChange(value.filter((k) => k !== keyword))}
-                  className="hover:opacity-70 transition-opacity"
-                  aria-label={`${keyword} 제거`}
-                >
-                  <X size={12} />
-                </button>
-              </span>
-            ))}
+                <X size={12} />
+              </button>
+            </span>
+          ))}
         </div>
       )}
 
-      {/* 직접 입력 */}
+      {/* 입력 */}
       <div className="flex flex-col gap-2 sm:flex-row">
         <input
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder={value.length >= MAX_KEYWORDS ? `최대 ${MAX_KEYWORDS}개까지 가능해요` : '직접 입력 후 Enter'}
+          placeholder={value.length >= MAX_KEYWORDS ? `최대 ${MAX_KEYWORDS}개까지 가능해요` : '키워드를 입력 후 Enter'}
           disabled={value.length >= MAX_KEYWORDS}
           className="flex-1 rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-4 py-2 text-sm text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-teal-500 disabled:opacity-50 transition-colors"
         />
         <button
           type="button"
-          onClick={addCustom}
+          onClick={addKeyword}
           disabled={!input.trim() || value.length >= MAX_KEYWORDS}
           className="w-full rounded-xl bg-teal-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-teal-600 disabled:opacity-40 sm:w-auto"
         >

--- a/components/diary/diaryOptions.ts
+++ b/components/diary/diaryOptions.ts
@@ -16,7 +16,7 @@ export const WEATHER_OPTIONS = [
   { key: 'rainy',  icon: CloudRain, label: '비' },
   { key: 'snowy',  icon: CloudSnow, label: '눈' },
   { key: 'hail',   icon: CloudHail, label: '우박' },
-  { key: 'windy',  icon: Wind,      label: '태풍' },
+  { key: 'typhoon', icon: Wind,     label: '태풍' },
 ] as const;
 
 export type EmotionOption = typeof EMOTION_OPTIONS[number];

--- a/components/pages/DiaryDetailPage.tsx
+++ b/components/pages/DiaryDetailPage.tsx
@@ -1,10 +1,83 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Pencil, Trash2, ThumbsUp, ThumbsDown, X } from 'lucide-react';
 import { Diary } from '../../types';
-import { getDiaryById, deleteDiary } from '../../api/diaryMock';
+import { getDiaryById } from '../../api/diaryMock';
+import { deleteDiary, ApiError } from '../../api/diary';
 import { EMOTION_OPTIONS, WEATHER_OPTIONS } from '../diary/diaryOptions';
 import UniversalHeader from '../layout/UniversalHeader';
+
+const ImageCarousel: React.FC<{ images: string[] }> = ({ images }) => {
+  const [index, setIndex] = useState(0);
+  const touchStartX = useRef<number | null>(null);
+  const mouseStartX = useRef<number | null>(null);
+
+  const prev = () => setIndex((i) => Math.max(i - 1, 0));
+  const next = () => setIndex((i) => Math.min(i + 1, images.length - 1));
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+  const onTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const delta = touchStartX.current - e.changedTouches[0].clientX;
+    if (delta > 40) next();
+    else if (delta < -40) prev();
+    touchStartX.current = null;
+  };
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    mouseStartX.current = e.clientX;
+  };
+  const onMouseUp = (e: React.MouseEvent) => {
+    if (mouseStartX.current === null) return;
+    const delta = mouseStartX.current - e.clientX;
+    if (delta > 40) next();
+    else if (delta < -40) prev();
+    mouseStartX.current = null;
+  };
+
+  return (
+    <div
+      className="relative w-full h-52 overflow-hidden select-none cursor-grab active:cursor-grabbing"
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+      onMouseDown={onMouseDown}
+      onMouseUp={onMouseUp}
+    >
+      <div
+        className="flex h-full w-full transition-transform duration-300 ease-out"
+        style={{ transform: `translateX(-${index * 100}%)` }}
+      >
+        {images.map((src, i) => (
+          <div key={i} className="w-full h-full flex-shrink-0">
+            <img src={src} alt="" className="w-full h-full object-cover pointer-events-none" draggable={false} />
+          </div>
+        ))}
+      </div>
+
+      {images.length > 1 && (
+        <span className="absolute top-2.5 right-2.5 text-[11px] font-semibold bg-black/50 text-white px-2 py-0.5 rounded-full">
+          {index + 1} / {images.length}
+        </span>
+      )}
+
+      {images.length > 1 && (
+        <div className="absolute bottom-2.5 left-0 right-0 flex justify-center gap-1.5">
+          {images.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => setIndex(i)}
+              className={`h-1.5 rounded-full transition-all duration-200 ${
+                i === index ? 'w-4 bg-white' : 'w-1.5 bg-white/50'
+              }`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
 
 const SATISFACTION_LABELS: Record<number, string> = {
   1: '매우 불만족',
@@ -58,8 +131,16 @@ const DiaryDetailPage: React.FC<DiaryDetailPageProps> = ({ id, onBack, onEdit, o
       await deleteDiary(id);
       onDeleted();
     } catch (e: unknown) {
-      const err = e as Error;
-      alert(err.message ?? '삭제에 실패했습니다.');
+      if (e instanceof ApiError) {
+        if (e.errorCode === 'EN_02_001') {
+          alert('존재하지 않는 일기입니다.');
+        } else {
+          alert(e.message);
+        }
+      } else {
+        const err = e as Error;
+        alert(err.message ?? '삭제에 실패했습니다.');
+      }
       setIsDeleting(false);
       setIsDeleteConfirm(false);
     }
@@ -152,6 +233,26 @@ const DiaryDetailPage: React.FC<DiaryDetailPageProps> = ({ id, onBack, onEdit, o
                 </h2>
               </div>
 
+              {/* 사진 */}
+              {diary.images.length > 0 && (
+                <div className="rounded-2xl overflow-hidden">
+                  <ImageCarousel images={diary.images} />
+                </div>
+              )}
+
+              {/* 오늘 하루 */}
+              <div className="flex-1 flex flex-col rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 overflow-hidden">
+                {diary.content ? (
+                  <p className="flex-1 px-4 py-3 text-sm leading-relaxed text-slate-700 dark:text-slate-200 whitespace-pre-wrap">
+                    {diary.content}
+                  </p>
+                ) : (
+                  <p className="flex-1 px-4 py-3 text-sm text-slate-400 dark:text-slate-500 italic">
+                    내용이 없습니다.
+                  </p>
+                )}
+              </div>
+
               {/* 감정 & 날씨 & 에너지 & 만족도 */}
               <div className="grid grid-cols-2 gap-3">
                 {emotionOption && (
@@ -224,20 +325,20 @@ const DiaryDetailPage: React.FC<DiaryDetailPageProps> = ({ id, onBack, onEdit, o
               )}
 
               {/* 회고 */}
-              {(diary.goodThings.length > 0 || diary.badThings.length > 0) && (
+              {(diary.achievement.length > 0 || diary.regret.length > 0) && (
                 <div className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
                   <p className="text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-4">
                     회고
                   </p>
                   <div className="flex flex-col sm:flex-row gap-4">
-                    {diary.goodThings.length > 0 && (
+                    {diary.achievement.length > 0 && (
                       <div className="flex-1 space-y-2">
                         <div className="flex items-center gap-1.5 text-sm font-semibold text-teal-600 dark:text-teal-400">
                           <ThumbsUp size={14} />
                           <span>잘한 일</span>
                         </div>
                         <ul className="space-y-1.5">
-                          {diary.goodThings.map((item, i) => (
+                          {diary.achievement.map((item, i) => (
                             <li key={i} className="text-sm text-slate-700 dark:text-slate-200 flex items-start gap-2">
                               <span className="text-teal-500 mt-0.5">·</span>
                               {item}
@@ -246,17 +347,17 @@ const DiaryDetailPage: React.FC<DiaryDetailPageProps> = ({ id, onBack, onEdit, o
                         </ul>
                       </div>
                     )}
-                    {diary.goodThings.length > 0 && diary.badThings.length > 0 && (
+                    {diary.achievement.length > 0 && diary.regret.length > 0 && (
                       <div className="hidden sm:block w-px bg-slate-200 dark:bg-slate-700" />
                     )}
-                    {diary.badThings.length > 0 && (
+                    {diary.regret.length > 0 && (
                       <div className="flex-1 space-y-2">
                         <div className="flex items-center gap-1.5 text-sm font-semibold text-slate-500 dark:text-slate-400">
                           <ThumbsDown size={14} />
                           <span>아쉬운 일</span>
                         </div>
                         <ul className="space-y-1.5">
-                          {diary.badThings.map((item, i) => (
+                          {diary.regret.map((item, i) => (
                             <li key={i} className="text-sm text-slate-700 dark:text-slate-200 flex items-start gap-2">
                               <span className="text-slate-400 mt-0.5">·</span>
                               {item}
@@ -268,22 +369,6 @@ const DiaryDetailPage: React.FC<DiaryDetailPageProps> = ({ id, onBack, onEdit, o
                   </div>
                 </div>
               )}
-
-              {/* 일기 본문 */}
-              <div className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
-                <p className="text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
-                  오늘 하루
-                </p>
-                {diary.content ? (
-                  <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200 whitespace-pre-wrap">
-                    {diary.content}
-                  </p>
-                ) : (
-                  <p className="text-sm text-slate-400 dark:text-slate-500 italic">
-                    내용이 없습니다.
-                  </p>
-                )}
-              </div>
             </motion.div>
           )}
         </div>

--- a/components/pages/DiaryEditPage.tsx
+++ b/components/pages/DiaryEditPage.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
+import { Camera, X } from 'lucide-react';
 import { useDiaryForm } from '../../hooks/useDiaryForm';
 import { getDiaryById } from '../../api/diaryMock';
 import EmotionPicker from '../diary/EmotionPicker';
@@ -19,6 +20,9 @@ interface DiaryEditPageProps {
 const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) => {
   const [isLoadingDiary, setIsLoadingDiary] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const MAX_IMAGES = 9;
+  const [loadingImagesCount, setLoadingImagesCount] = useState(0);
 
   const {
     date, setDate,
@@ -28,8 +32,9 @@ const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) =>
     energy, setEnergy,
     satisfaction, setSatisfaction,
     keywords, setKeywords,
-    goodThings, setGoodThings,
-    badThings, setBadThings,
+    achievement, setAchievement,
+    regret, setRegret,
+    images, setImages,
     isSubmitting, submitError, canSubmit,
     initForm,
     handleUpdate,
@@ -47,8 +52,9 @@ const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) =>
           energy: diary.energy,
           satisfaction: diary.satisfaction,
           keywords: diary.keywords,
-          goodThings: diary.goodThings,
-          badThings: diary.badThings,
+          achievement: diary.achievement,
+          regret: diary.regret,
+          images: diary.images,
         });
       } catch (e: unknown) {
         const err = e as Error;
@@ -60,6 +66,33 @@ const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) =>
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
+
+  const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    const remaining = MAX_IMAGES - images.length;
+    const filesToProcess = Math.min(files.length, remaining);
+    if (filesToProcess <= 0) return;
+
+    setLoadingImagesCount(filesToProcess);
+
+    Array.from<File>(files).slice(0, filesToProcess).forEach((file) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result === 'string') {
+          const dataUrl = reader.result;
+          setImages((prev) => [...prev, dataUrl]);
+        }
+        setLoadingImagesCount((prev) => Math.max(0, prev - 1));
+      };
+      reader.readAsDataURL(file);
+    });
+    e.target.value = '';
+  };
+
+  const handleRemoveImage = (index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+  };
 
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-[#0f172a] transition-colors flex flex-col">
@@ -106,7 +139,74 @@ const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) =>
                 />
               </section>
 
-              {/* 1. 감정 */}
+              {/* 사진 */}
+              <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
+                <label className="block text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
+                  사진 {images.length}/{MAX_IMAGES}
+                </label>
+                <div className="grid grid-cols-3 gap-3">
+                  {images.map((img, i) => (
+                    <div key={i} className="relative aspect-square rounded-xl overflow-hidden group">
+                      <img
+                        src={img}
+                        alt=""
+                        className="w-full h-full object-cover"
+                        onLoad={() => {
+                          /* image loaded successfully */
+                        }}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveImage(i)}
+                        className="absolute top-1.5 right-1.5 w-6 h-6 rounded-full bg-black/50 text-white flex items-center justify-center opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+                      >
+                        <X size={14} />
+                      </button>
+                    </div>
+                  ))}
+                  {loadingImagesCount > 0 &&
+                    Array.from({ length: loadingImagesCount }).map((_, i) => (
+                      <div
+                        key={`loading-${i}`}
+                        className="aspect-square rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse"
+                      />
+                    ))}
+                  {images.length < MAX_IMAGES && (
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      className="aspect-square rounded-xl border-2 border-dashed border-slate-200 dark:border-slate-700 flex flex-col items-center justify-center gap-1 text-slate-400 dark:text-slate-500 hover:border-teal-400 hover:text-teal-500 transition-colors"
+                    >
+                      <Camera size={20} />
+                      <span className="text-[10px] font-medium">사진 추가</span>
+                    </button>
+                  )}
+                </div>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  onChange={handleImageSelect}
+                  className="hidden"
+                />
+              </section>
+
+              {/* 오늘 하루 */}
+              <section className="flex-1 flex flex-col rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 overflow-hidden">
+                <textarea
+                  value={content}
+                  onChange={(e) => setContent(e.target.value)}
+                  placeholder="오늘 하루를 기록해보세요..."
+                  maxLength={2500}
+                  className="flex-1 w-full min-h-[200px] bg-transparent px-4 py-3 text-sm text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none resize-none transition-colors"
+                />
+                <div className="px-4 pb-2 text-right text-[11px] text-slate-400 dark:text-slate-500">
+                  {content.length}/2500
+                </div>
+              </section>
+
+              {/* 감정 */}
               <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
                 <label className="block text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
                   오늘의 감정
@@ -114,23 +214,7 @@ const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) =>
                 <EmotionPicker value={emotion} onChange={setEmotion} />
               </section>
 
-              {/* 2. 에너지 */}
-              <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
-                <label className="block text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
-                  에너지
-                </label>
-                <EnergySlider value={energy} onChange={setEnergy} />
-              </section>
-
-              {/* 3. 만족도 */}
-              <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
-                <label className="block text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
-                  하루 만족도
-                </label>
-                <SatisfactionSlider value={satisfaction} onChange={setSatisfaction} />
-              </section>
-
-              {/* 4. 날씨 */}
+              {/* 날씨 */}
               <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
                 <label className="block text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
                   오늘의 날씨
@@ -138,7 +222,23 @@ const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) =>
                 <WeatherPicker value={weather} onChange={setWeather} />
               </section>
 
-              {/* 5. 키워드 */}
+              {/* 에너지 */}
+              <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
+                <label className="block text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
+                  에너지
+                </label>
+                <EnergySlider value={energy} onChange={setEnergy} />
+              </section>
+
+              {/* 만족도 */}
+              <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
+                <label className="block text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
+                  하루 만족도
+                </label>
+                <SatisfactionSlider value={satisfaction} onChange={setSatisfaction} />
+              </section>
+
+              {/* 키워드 */}
               <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
                 <label className="block text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
                   오늘의 키워드
@@ -146,30 +246,16 @@ const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) =>
                 <KeywordPicker value={keywords} onChange={setKeywords} />
               </section>
 
-              {/* 6. 회고 */}
+              {/* 회고 */}
               <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
                 <label className="block text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-4">
                   오늘의 회고
                 </label>
                 <ReflectionInput
-                  goodThings={goodThings}
-                  badThings={badThings}
-                  onGoodChange={setGoodThings}
-                  onBadChange={setBadThings}
-                />
-              </section>
-
-              {/* 7. 일기 본문 */}
-              <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
-                <label className="block text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
-                  오늘 하루
-                </label>
-                <textarea
-                  value={content}
-                  onChange={(e) => setContent(e.target.value)}
-                  placeholder="오늘 하루를 기록해보세요..."
-                  rows={8}
-                  className="w-full rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-4 py-3 text-sm text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-teal-500 resize-none transition-colors"
+                  goodThings={achievement}
+                  badThings={regret}
+                  onGoodChange={setAchievement}
+                  onBadChange={setRegret}
                 />
               </section>
 

--- a/components/pages/DiaryWritePage.tsx
+++ b/components/pages/DiaryWritePage.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { motion } from 'framer-motion';
+import { Camera, X } from 'lucide-react';
 import { useDiaryForm } from '../../hooks/useDiaryForm';
 import EmotionPicker from '../diary/EmotionPicker';
 import WeatherPicker from '../diary/WeatherPicker';
@@ -23,14 +24,52 @@ const DiaryWritePage: React.FC<DiaryWritePageProps> = ({ onBack, onSaved }) => {
     energy, setEnergy,
     satisfaction, setSatisfaction,
     keywords, setKeywords,
-    goodThings, setGoodThings,
-    badThings, setBadThings,
+    achievement, setAchievement,
+    regret, setRegret,
+    images, setImages,
     isSubmitting, submitError, canSubmit,
     handleCreate,
   } = useDiaryForm({ onCreateSuccess: onSaved });
 
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const MAX_IMAGES = 9;
+  const [loadingImagesCount, setLoadingImagesCount] = useState(0);
+
+  const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    const remaining = MAX_IMAGES - images.length;
+    const filesToProcess = Math.min(files.length, remaining);
+    if (filesToProcess <= 0) return;
+
+    setLoadingImagesCount(filesToProcess);
+    const newImages: string[] = [];
+    let completedCount = 0;
+
+    Array.from(files).slice(0, filesToProcess).forEach((file: File) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result === 'string') {
+          newImages.push(reader.result);
+        }
+        completedCount++;
+        if (completedCount === filesToProcess) {
+          setImages((prev) => [...prev, ...newImages]);
+          setLoadingImagesCount(0);
+        }
+      };
+      reader.readAsDataURL(file);
+    });
+    e.target.value = '';
+  };
+
+  const handleRemoveImage = (index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+  };
+
   return (
-    <div className="flex min-h-screen flex-col overflow-x-hidden bg-slate-50 transition-colors dark:bg-[#0f172a]">
+    <div className="flex min-h-screen flex-col overflow-x-hidden bg-slate-50 dark:bg-[#0f172a] transition-colors">
       <UniversalHeader
         title="일기 쓰기"
         onBack={onBack}
@@ -57,8 +96,76 @@ const DiaryWritePage: React.FC<DiaryWritePageProps> = ({ onBack, onSaved }) => {
               />
             </section>
 
+            {/* 사진 */}
+            <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
+              <div className="flex items-center justify-between mb-3">
+                <label className="block text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400">
+                  사진
+                </label>
+                <span className="text-[11px] font-medium text-slate-400 dark:text-slate-500">
+                  {images.length}/{MAX_IMAGES}
+                </span>
+              </div>
+              <div className="grid grid-cols-3 gap-3">
+                {images.map((img, i) => (
+                  <div key={i} className="relative aspect-square rounded-xl overflow-hidden group">
+                    <img
+                      src={img}
+                      alt=""
+                      className="w-full h-full object-cover"
+                      onLoad={() => {
+                        // Image loaded successfully
+                      }}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveImage(i)}
+                      className="absolute top-1.5 right-1.5 w-6 h-6 rounded-full bg-black/50 text-white flex items-center justify-center opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                ))}
+                {Array.from({ length: loadingImagesCount }).map((_, i) => (
+                  <div key={`loading-${i}`} className="aspect-square rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
+                ))}
+                {images.length < MAX_IMAGES && (
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="aspect-square rounded-xl border-2 border-dashed border-slate-200 dark:border-slate-700 flex flex-col items-center justify-center gap-1 text-slate-400 dark:text-slate-500 hover:border-teal-400 hover:text-teal-500 transition-colors"
+                  >
+                    <Camera size={20} />
+                    <span className="text-[10px] font-medium">사진 추가</span>
+                  </button>
+                )}
+              </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                onChange={handleImageSelect}
+                className="hidden"
+              />
+            </section>
+
+            {/* 오늘 하루 */}
+            <section className="flex-1 flex flex-col rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 overflow-hidden">
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="오늘 하루를 기록해보세요..."
+                maxLength={2500}
+                className="flex-1 w-full min-h-[200px] bg-transparent px-4 py-3 text-sm text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none resize-none transition-colors"
+              />
+              <div className="px-4 pb-2 text-right text-[11px] text-slate-400 dark:text-slate-500">
+                {content.length}/2500
+              </div>
+            </section>
+
             <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
-              {/* 1. 감정 */}
+              {/* 감정 */}
               <section className="min-w-0 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700/60 dark:bg-slate-900">
                 <label className="block text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
                   감정
@@ -66,7 +173,7 @@ const DiaryWritePage: React.FC<DiaryWritePageProps> = ({ onBack, onSaved }) => {
                 <EmotionPicker value={emotion} onChange={setEmotion} />
               </section>
 
-              {/* 2. 날씨 */}
+              {/* 날씨 */}
               <section className="min-w-0 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700/60 dark:bg-slate-900">
                 <label className="block text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
                   날씨
@@ -74,7 +181,7 @@ const DiaryWritePage: React.FC<DiaryWritePageProps> = ({ onBack, onSaved }) => {
                 <WeatherPicker value={weather} onChange={setWeather} />
               </section>
 
-              {/* 3. 만족도 */}
+              {/* 에너지 */}
               <section className="min-w-0 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700/60 dark:bg-slate-900 sm:col-span-2">
                 <label className="block text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
                   에너지
@@ -82,7 +189,7 @@ const DiaryWritePage: React.FC<DiaryWritePageProps> = ({ onBack, onSaved }) => {
                 <EnergySlider value={energy} onChange={setEnergy} />
               </section>
 
-              {/* 4. 만족도 */}
+              {/* 만족도 */}
               <section className="min-w-0 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700/60 dark:bg-slate-900 sm:col-span-2">
                 <label className="block text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
                   만족도
@@ -91,7 +198,7 @@ const DiaryWritePage: React.FC<DiaryWritePageProps> = ({ onBack, onSaved }) => {
               </section>
             </div>
 
-            {/* 5. 키워드 */}
+            {/* 키워드 */}
             <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
               <label className="block text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
                 오늘의 키워드
@@ -99,30 +206,16 @@ const DiaryWritePage: React.FC<DiaryWritePageProps> = ({ onBack, onSaved }) => {
               <KeywordPicker value={keywords} onChange={setKeywords} />
             </section>
 
-            {/* 6. 잘한 일 / 아쉬운 일 */}
+            {/* 회고 */}
             <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
               <label className="block text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-4">
                 오늘의 회고
               </label>
               <ReflectionInput
-                goodThings={goodThings}
-                badThings={badThings}
-                onGoodChange={setGoodThings}
-                onBadChange={setBadThings}
-              />
-            </section>
-
-            {/* 7. 일기 본문 */}
-            <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
-              <label className="block text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
-                오늘 하루
-              </label>
-              <textarea
-                value={content}
-                onChange={(e) => setContent(e.target.value)}
-                placeholder="오늘 하루를 기록해보세요..."
-                rows={8}
-                className="w-full rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-4 py-3 text-sm text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-teal-500 resize-none transition-colors"
+                goodThings={achievement}
+                badThings={regret}
+                onGoodChange={setAchievement}
+                onBadChange={setRegret}
               />
             </section>
 

--- a/config/env.ts
+++ b/config/env.ts
@@ -1,8 +1,9 @@
-type Profile = 'dev' | 'prod';
+type Profile = 'local' | 'dev' | 'prod';
 
-const profile = import.meta.env.MODE as Profile;
+const profile = (import.meta.env.MODE ?? 'local') as Profile;
 
 const hostMap: Record<Profile, string> = {
+  local: '',
   dev: 'https://dev-gateway.jifelog.com',
   prod: 'https://gateway.jifelog.com',
 };

--- a/hooks/useDiaryForm.ts
+++ b/hooks/useDiaryForm.ts
@@ -1,10 +1,12 @@
 import { useState } from 'react';
-import { DiaryFormState, EmotionKey, WeatherKey } from '../types';
-import { createDiary, updateDiary } from '../api/diaryMock';
+import { DiaryFormState, EmotionKey, WeatherKey, formStateToCreateRequest } from '../types';
+import { createDiary } from '../api/diary';
+import { updateDiary as updateDiaryMock } from '../api/diaryMock';
+import { ApiError } from '../api/auth';
 
 interface UseDiaryFormOptions {
   initialValues?: Partial<DiaryFormState>;
-  onCreateSuccess?: () => void;
+  onCreateSuccess?: (id: string) => void;
   onUpdateSuccess?: (id: string) => void;
 }
 
@@ -18,8 +20,9 @@ export function useDiaryForm({ initialValues, onCreateSuccess, onUpdateSuccess }
   const [energy, setEnergy] = useState<number | null>(initialValues?.energy ?? 3);
   const [satisfaction, setSatisfaction] = useState<number | null>(initialValues?.satisfaction ?? 3);
   const [keywords, setKeywords] = useState<string[]>(initialValues?.keywords ?? []);
-  const [goodThings, setGoodThings] = useState<string[]>(initialValues?.goodThings ?? []);
-  const [badThings, setBadThings] = useState<string[]>(initialValues?.badThings ?? []);
+  const [achievement, setAchievement] = useState<string[]>(initialValues?.achievement ?? []);
+  const [regret, setRegret] = useState<string[]>(initialValues?.regret ?? []);
+  const [images, setImages] = useState<string[]>(initialValues?.images ?? []);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
@@ -35,8 +38,9 @@ export function useDiaryForm({ initialValues, onCreateSuccess, onUpdateSuccess }
     setEnergy(values.energy);
     setSatisfaction(values.satisfaction);
     setKeywords(values.keywords);
-    setGoodThings(values.goodThings);
-    setBadThings(values.badThings);
+    setAchievement(values.achievement);
+    setRegret(values.regret);
+    setImages(values.images);
   }
 
   async function handleCreate() {
@@ -44,7 +48,7 @@ export function useDiaryForm({ initialValues, onCreateSuccess, onUpdateSuccess }
     setIsSubmitting(true);
     setSubmitError(null);
     try {
-      await createDiary({
+      const formState: DiaryFormState = {
         date,
         emotion: emotion as EmotionKey | null,
         weather: weather as WeatherKey | null,
@@ -52,13 +56,25 @@ export function useDiaryForm({ initialValues, onCreateSuccess, onUpdateSuccess }
         energy,
         satisfaction,
         keywords,
-        goodThings,
-        badThings,
-      });
-      onCreateSuccess?.();
+        achievement,
+        regret,
+        images,
+      };
+      const request = formStateToCreateRequest(formState);
+      const response = await createDiary(request);
+      onCreateSuccess?.(response.id);
     } catch (e: unknown) {
-      const err = e as Error;
-      setSubmitError(err.message ?? '저장에 실패했습니다.');
+      if (e instanceof ApiError) {
+        // 409: 같은 날짜에 이미 일기가 존재
+        if (e.errorCode === 'EC_02_001') {
+          setSubmitError('이미 작성된 일기가 존재합니다.');
+        } else {
+          setSubmitError(e.message);
+        }
+      } else {
+        const err = e as Error;
+        setSubmitError(err.message ?? '저장에 실패했습니다.');
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -69,7 +85,7 @@ export function useDiaryForm({ initialValues, onCreateSuccess, onUpdateSuccess }
     setIsSubmitting(true);
     setSubmitError(null);
     try {
-      await updateDiary(id, {
+      const formState: DiaryFormState = {
         date,
         emotion: emotion as EmotionKey | null,
         weather: weather as WeatherKey | null,
@@ -77,13 +93,30 @@ export function useDiaryForm({ initialValues, onCreateSuccess, onUpdateSuccess }
         energy,
         satisfaction,
         keywords,
-        goodThings,
-        badThings,
+        achievement,
+        regret,
+        images,
+      };
+      await updateDiaryMock(id, {
+        date: formState.date,
+        emotion: formState.emotion,
+        weather: formState.weather,
+        content: formState.content,
+        energy: formState.energy,
+        satisfaction: formState.satisfaction,
+        keywords: formState.keywords,
+        achievement: formState.achievement,
+        regret: formState.regret,
+        images: formState.images,
       });
       onUpdateSuccess?.(id);
     } catch (e: unknown) {
-      const err = e as Error;
-      setSubmitError(err.message ?? '수정에 실패했습니다.');
+      if (e instanceof ApiError) {
+        setSubmitError(e.message);
+      } else {
+        const err = e as Error;
+        setSubmitError(err.message ?? '수정에 실패했습니다.');
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -97,8 +130,9 @@ export function useDiaryForm({ initialValues, onCreateSuccess, onUpdateSuccess }
     energy, setEnergy,
     satisfaction, setSatisfaction,
     keywords, setKeywords,
-    goodThings, setGoodThings,
-    badThings, setBadThings,
+    achievement, setAchievement,
+    regret, setRegret,
+    images, setImages,
     isSubmitting,
     submitError,
     canSubmit,

--- a/types.ts
+++ b/types.ts
@@ -92,8 +92,10 @@ export interface DriveFile {
 }
 
 // 일기 관련 타입
+
+// --- 프론트엔드 UI 모델 ---
 export type EmotionKey = 'happy' | 'sad' | 'angry' | 'neutral' | 'excited' | 'anxious' | 'tired';
-export type WeatherKey = 'sunny' | 'cloudy' | 'rainy' | 'snowy' | 'hail' | 'windy';
+export type WeatherKey = 'sunny' | 'cloudy' | 'rainy' | 'snowy' | 'hail' | 'typhoon';
 
 export interface Diary {
   id: string;
@@ -104,8 +106,9 @@ export interface Diary {
   energy: number | null;  // 1~5
   satisfaction: number | null;  // 1~5
   keywords: string[];
-  goodThings: string[];
-  badThings: string[];
+  achievement: string[];
+  regret: string[];
+  images: string[];
   createdAt: string;
   updatedAt: string;
 }
@@ -118,22 +121,105 @@ export interface DiaryFormState {
   energy: number | null;
   satisfaction: number | null;
   keywords: string[];
-  goodThings: string[];
-  badThings: string[];
+  achievement: string[];
+  regret: string[];
+  images: string[];
 }
 
-export interface DiaryCreateRequest {
-  date: string;
-  emotion: EmotionKey | null;
-  weather: WeatherKey | null;
-  content: string;
-  energy: number | null;
-  satisfaction: number | null;
+// --- API 모델 (OpenAPI 스펙 매칭) ---
+export type Mood = 'HAPPY' | 'EXCITED' | 'NEUTRAL' | 'SAD' | 'ANGRY' | 'ANXIOUS' | 'TIRED';
+export type Weather = 'SUNNY' | 'CLOUDY' | 'RAIN' | 'SNOW' | 'HAIL' | 'TYPHOON';
+
+export interface CreateDiaryRequest {
+  entryDate: string;          // YYYY-MM-DD
+  mood: Mood;
+  weather: Weather;
+  energyLevel: number;        // 1~5
+  satisfactionLevel: number;  // 1~5
   keywords: string[];
-  goodThings: string[];
-  badThings: string[];
+  achievement: string[];
+  regret: string[];
+  content: string;
+  images?: string[];
 }
 
+export interface CreateDiaryResponse {
+  id: string;  // UUID
+}
+
+// --- EmotionKey ↔ Mood 변환 ---
+const EMOTION_TO_MOOD: Record<EmotionKey, Mood> = {
+  happy: 'HAPPY',
+  excited: 'EXCITED',
+  neutral: 'NEUTRAL',
+  sad: 'SAD',
+  angry: 'ANGRY',
+  anxious: 'ANXIOUS',
+  tired: 'TIRED',
+};
+
+const MOOD_TO_EMOTION: Record<Mood, EmotionKey> = {
+  HAPPY: 'happy',
+  EXCITED: 'excited',
+  NEUTRAL: 'neutral',
+  SAD: 'sad',
+  ANGRY: 'angry',
+  ANXIOUS: 'anxious',
+  TIRED: 'tired',
+};
+
+export function toMood(key: EmotionKey): Mood {
+  return EMOTION_TO_MOOD[key];
+}
+
+export function toEmotionKey(mood: Mood): EmotionKey {
+  return MOOD_TO_EMOTION[mood];
+}
+
+// --- WeatherKey ↔ Weather 변환 ---
+const WEATHER_KEY_TO_API: Record<WeatherKey, Weather> = {
+  sunny: 'SUNNY',
+  cloudy: 'CLOUDY',
+  rainy: 'RAIN',
+  snowy: 'SNOW',
+  hail: 'HAIL',
+  typhoon: 'TYPHOON',
+};
+
+const API_TO_WEATHER_KEY: Record<Weather, WeatherKey> = {
+  SUNNY: 'sunny',
+  CLOUDY: 'cloudy',
+  RAIN: 'rainy',
+  SNOW: 'snowy',
+  HAIL: 'hail',
+  TYPHOON: 'typhoon',
+};
+
+export function toWeatherEnum(key: WeatherKey): Weather {
+  return WEATHER_KEY_TO_API[key];
+}
+
+export function toWeatherKey(weather: Weather): WeatherKey {
+  return API_TO_WEATHER_KEY[weather];
+}
+
+// --- DiaryFormState → CreateDiaryRequest 변환 ---
+export function formStateToCreateRequest(form: DiaryFormState): CreateDiaryRequest {
+  return {
+    entryDate: form.date,
+    mood: toMood(form.emotion ?? 'neutral'),
+    weather: toWeatherEnum(form.weather ?? 'sunny'),
+    energyLevel: form.energy ?? 3,
+    satisfactionLevel: form.satisfaction ?? 3,
+    keywords: form.keywords,
+    achievement: form.achievement,
+    regret: form.regret,
+    content: form.content,
+    images: form.images,
+  };
+}
+
+// --- 기존 호환성 (deprecated, 점진적 마이그레이션용) ---
 export interface DiaryUpdateRequest {
   date?: string;
   emotion?: EmotionKey | null;
@@ -142,6 +228,7 @@ export interface DiaryUpdateRequest {
   energy?: number | null;
   satisfaction?: number | null;
   keywords?: string[];
-  goodThings?: string[];
-  badThings?: string[];
+  achievement?: string[];
+  regret?: string[];
+  images?: string[];
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,16 @@ export default defineConfig(({ mode }) => {
       server: {
         port: 3000,
         host: '0.0.0.0',
+        proxy: {
+          '/v1': {
+            target: 'http://localhost:8080',
+            changeOrigin: true,
+          },
+          '/auth': {
+            target: 'http://localhost:8080',
+            changeOrigin: true,
+          },
+        },
       },
       plugins: [react(), basicSsl()],
       define: {


### PR DESCRIPTION
## 개요

일기 도메인의 실제 백엔드 API 연동을 준비하고, UI 모델과 API 모델을 분리하며 사진 기능과 필드 리네임을 반영합니다.

Closes #45

---

## 변경 사항

### API 클라이언트 계층 구축
- `api/httpClient.ts` — `apiRequest` 공통 HTTP 클라이언트 + `ApiError` 클래스
- `api/caseConverter.ts` — camelCase ↔ snake_case 재귀 변환 유틸
- `api/auth.ts` — 기존 mock 의존 제거, `httpClient` 기반 리팩토링
- `api/diary.ts` — `createDiary` → 실제 API 호출(`POST /v1/entries`)로 전환
- `api/diaryMock.ts` — mock 필드명 `goodThings/badThings` → `achievement/regret`, `images` 추가
- `api/signup.ts` — `ApiErrorData/ApiErrorResponse` export를 `httpClient`에서 가져오도록 변경
- `config/env.ts` — `local` 프로필 추가 (프록시용 빈 host)
- `vite.config.ts` — `/v1`, `/auth` → `localhost:8080` 프록시 설정

### 타입 시스템 분리
- `types.ts` — `Mood`, `Weather` API enum, 변환 함수, `formStateToCreateRequest()` 변환기 추가
- `goodThings/badThings` → `achievement/regret`, `images` 필드 추가

### UI 컴포넌트 개선
- `DiaryCard.tsx` — 썸네일 이미지 표시
- `DiaryDetailPage.tsx` — `ImageCarousel`(스와이프+인디케이터), `ApiError` 에러 처리
- `DiaryEditPage.tsx` / `DiaryWritePage.tsx` — 사진 업로드·삭제 UI, 섹션 순서 재배치
- `KeywordPicker.tsx` — 프리셋 키워드 제거, 직접 입력 방식으로 단순화
- `diaryOptions.ts` — `windy` → `typhoon` 키 변경

### 폼 훅
- `hooks/useDiaryForm.ts` — `createDiary` 실제 API 호출, `ApiError` 에러 처리 (409 중복, 404 미존재)

---

## 체크리스트

- [ ] `api/httpClient` 요청/응답 변환 동작 확인
- [ ] `POST /v1/entries` API 연동 테스트
- [ ] 사진 업로드·캐러셀 UI 동작 확인
- [ ] `achievement/regret` 필드 하위호환성 확인
- [ ] `ApiError` 에러 코드별 메시지 처리 확인
- [ ] vite proxy 로컬 개발 환경 정상 동작 확인