### PR TITLE
feat: 일기 초안 작성 기능

### DIFF
--- a/api/diaryDraft.ts
+++ b/api/diaryDraft.ts
@@ -1,0 +1,75 @@
+// 일기 초안 생성 (LLM 호출 래퍼)
+// 현재는 백엔드 LLM 엔드포인트가 없으므로 클라이언트에서 답변을 합성해 초안을 생성한다.
+// 추후 실제 LLM API가 연결되면 이 함수만 교체하면 된다.
+
+export interface DiaryDraftAnswers {
+  q1Events: string;        // 오늘 하루 사건들 (시간 순)
+  q2Memorable: string;     // 가장 기억에 남은 순간 + 감정
+  q3Condition: string;      // 컨디션과 영향
+  q4Achievement: string;    // 잘한 점
+  q4Regret: string;         // 아쉬운 점
+  q5Closing: string;        // 한 줄 요약 / 내일의 나에게
+}
+
+export interface DiaryDraftResult {
+  content: string;
+  achievement: string[];
+  regret: string[];
+}
+
+function splitSentences(text: string): string[] {
+  return text
+    .split(/[\n.!?]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * 5개 질문 답변을 일기 본문 + 회고 항목으로 합성한다.
+ * 답변의 문맥을 최대한 보존하되, 일기 형식으로 자연스럽게 이어 붙인다.
+ */
+export function generateDiaryDraft(answers: DiaryDraftAnswers): DiaryDraftResult {
+  const paragraphs: string[] = [];
+
+  // 1. 하루 사건 (뼈대)
+  if (answers.q1Events.trim()) {
+    paragraphs.push(answers.q1Events.trim());
+  }
+
+  // 2. 기억에 남은 순간 + 감정 (클라이맥스)
+  if (answers.q2Memorable.trim()) {
+    paragraphs.push(`가장 기억에 남는 순간은 ${answers.q2Memorable.trim()}`);
+  }
+
+  // 3. 컨디션과 영향 (맥락)
+  if (answers.q3Condition.trim()) {
+    paragraphs.push(answers.q3Condition.trim());
+  }
+
+  // 4. 회고 (잘한 점 / 아쉬운 점) — 본문에는 요약, 항목은 분리해 추출
+  const achievementText = answers.q4Achievement.trim();
+  const regretText = answers.q4Regret.trim();
+  if (achievementText || regretText) {
+    const reflectionParts: string[] = [];
+    if (achievementText) reflectionParts.push(`잘한 점은 ${achievementText}`);
+    if (regretText) reflectionParts.push(`아쉬운 점은 ${regretText}`);
+    paragraphs.push(`스스로 돌아보면, ${reflectionParts.join(', ')}.`);
+  }
+
+  // 5. 클로징 멘트
+  if (answers.q5Closing.trim()) {
+    paragraphs.push(answers.q5Closing.trim());
+  }
+
+  const content = paragraphs.filter(Boolean).join('\n\n');
+
+  // 회고 항목 추출: 각 입력값을 문장 단위로 분리
+  const achievement = achievementText ? splitSentences(achievementText) : [];
+  const regret = regretText ? splitSentences(regretText) : [];
+
+  return {
+    content,
+    achievement,
+    regret,
+  };
+}

--- a/components/pages/DiaryDraftPage.tsx
+++ b/components/pages/DiaryDraftPage.tsx
@@ -1,0 +1,365 @@
+import React, { useRef, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Sparkles, ChevronRight, Check } from 'lucide-react';
+import UniversalHeader from '../layout/UniversalHeader';
+import { generateDiaryDraft, DiaryDraftAnswers, DiaryDraftResult } from '../../api/diaryDraft';
+
+interface DiaryDraftPageProps {
+  onBack: () => void;
+  onDraftGenerated: (draft: DiaryDraftResult) => void;
+}
+
+interface SingleField {
+  kind: 'single';
+  id: keyof DiaryDraftAnswers;
+  title: string;
+  placeholder: string;
+  helper: string;
+}
+
+interface MultiField {
+  kind: 'multi';
+  id: string;
+  title: string;
+  helper: string;
+  fields: {
+    id: keyof DiaryDraftAnswers;
+    label: string;
+    placeholder: string;
+  }[];
+}
+
+type Question = SingleField | MultiField;
+
+const QUESTIONS: Question[] = [
+  {
+    kind: 'single',
+    id: 'q1Events',
+    title: '오늘 하루를 시간 순서대로 떠올려보면, 어떤 일들이 있었나요?',
+    placeholder:
+      '아침엔 늦잠 자서 정신없이 출근, 점심에 팀원이랑 새로 생긴 파스타집 감, 오후엔 회의가 길어져서 야근, 퇴근길에 비가 와서 우산 없이 뛰어옴',
+    helper: '하루의 뼈대가 되는 사건들을 자유롭게 나열해주세요.',
+  },
+  {
+    kind: 'single',
+    id: 'q2Memorable',
+    title: '그 중에서 가장 기억에 남거나 마음이 움직인 순간은 언제였고, 그때 기분이 어땠나요?',
+    placeholder:
+      '회의에서 내 의견이 받아들여졌을 때 뿌듯했음. 근데 그 직후에 실수를 지적받아서 살짝 위축되기도 했음',
+    helper: '사건과 감정, 감정의 변화까지 적어주면 일기의 감정선이 살아납니다.',
+  },
+  {
+    kind: 'single',
+    id: 'q3Condition',
+    title: '오늘 하루를 지내면서 몸이나 마음의 컨디션은 어땠나요? 그게 하루에 어떤 영향을 줬나요?',
+    placeholder:
+      '잠을 4시간밖에 못 자서 오전 내내 멍했는데, 커피 마시고 오후엔 좀 살아남. 그래서 집중이 잘 안 돼서 일이 밀림',
+    helper: '컨디션과 그로 인한 영향(원인-결과)까지 적어주면 맥락이 더해집니다.',
+  },
+  {
+    kind: 'multi',
+    id: 'q4Reflection',
+    title: '오늘 있었던 일들 중, 스스로 잘했다고 느낀 점과 아쉬웠던 점을 각각 적어주세요.',
+    helper: '잘한 점과 아쉬운 점을 분리해 적으면 더 정확한 회고가 됩니다.',
+    fields: [
+      {
+        id: 'q4Achievement',
+        label: '잘한 점',
+        placeholder: '미루던 연락을 먼저 함',
+      },
+      {
+        id: 'q4Regret',
+        label: '아쉬운 점',
+        placeholder: '운동을 또 걸렀고, 야식을 먹었음',
+      },
+    ],
+  },
+  {
+    kind: 'single',
+    id: 'q5Closing',
+    title: '오늘을 한 문장으로 요약하거나, 내일의 나에게 하고 싶은 말이 있다면요?',
+    placeholder:
+      '오늘은 널뛰던 하루였지만 그래도 잘 버텼다 / 내일은 일찍 자자, 내일 회의는 더 잘 준비해가자',
+    helper: '일기를 마무리하는 한 줄이 됩니다.',
+  },
+];
+
+const DiaryDraftPage: React.FC<DiaryDraftPageProps> = ({ onBack, onDraftGenerated }) => {
+  const [phase, setPhase] = useState<'questions' | 'review'>('questions');
+  const [step, setStep] = useState(0);
+  const [answers, setAnswers] = useState<DiaryDraftAnswers>({
+    q1Events: '',
+    q2Memorable: '',
+    q3Condition: '',
+    q4Achievement: '',
+    q4Regret: '',
+    q5Closing: '',
+  });
+  const [draft, setDraft] = useState<DiaryDraftResult | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const currentQuestion = QUESTIONS[step];
+  const isLastStep = step === QUESTIONS.length - 1;
+
+  const canProceed =
+    currentQuestion.kind === 'single'
+      ? answers[currentQuestion.id].trim().length > 0
+      : currentQuestion.fields.every((f) => answers[f.id].trim().length > 0);
+
+  const handleNext = () => {
+    if (!canProceed) return;
+    if (isLastStep) {
+      handleGenerate();
+      return;
+    }
+    setStep((prev) => prev + 1);
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+    });
+  };
+
+  const handlePrev = () => {
+    if (phase === 'review') {
+      setPhase('questions');
+      setError(null);
+      return;
+    }
+    if (step === 0) {
+      onBack();
+      return;
+    }
+    setStep((prev) => prev - 1);
+  };
+
+  const handleGenerate = async () => {
+    setIsGenerating(true);
+    setError(null);
+    try {
+      // LLM 호출(현재는 클라이언트 합성 mock). 추후 비동기 API 교체 대비 await 유지.
+      const result = await Promise.resolve(generateDiaryDraft(answers));
+      setDraft(result);
+      setPhase('review');
+    } catch (e: unknown) {
+      const err = e as Error;
+      setError(err.message ?? '초안 생성에 실패했습니다.');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const handleProceed = () => {
+    if (!draft) return;
+    onDraftGenerated(draft);
+  };
+
+  const handleChange = (id: keyof DiaryDraftAnswers) => (
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    setAnswers((prev) => ({ ...prev, [id]: e.target.value }));
+  };
+
+  // --- 리뷰 단계: 초안 본문 인라인 편집 ---
+  const updateDraftContent = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setDraft((prev) => (prev ? { ...prev, content: e.target.value } : prev));
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col overflow-x-hidden bg-slate-50 dark:bg-[#0f172a] transition-colors">
+      <UniversalHeader title="일기 초안 작성" onBack={onBack} showBack={true} />
+
+      <main className="min-w-0 flex-1 overflow-x-hidden overflow-y-auto pt-16 pb-[calc(env(safe-area-inset-bottom)+6rem)] md:pb-32">
+        <div className="mx-auto w-full max-w-2xl min-w-0 px-4 py-5 md:px-5 md:py-6">
+          {phase === 'questions' && (
+            <>
+              {/* 진행 표시 */}
+              <div className="mb-6 flex items-center gap-2">
+                {QUESTIONS.map((q, i) => (
+                  <div
+                    key={q.id}
+                    className={`h-1.5 flex-1 rounded-full transition-colors ${
+                      i <= step ? 'bg-teal-500' : 'bg-slate-200 dark:bg-slate-800'
+                    }`}
+                  />
+                ))}
+              </div>
+
+              <div className="mb-3 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400">
+                <Sparkles size={14} />
+                <span>
+                  {step + 1} / {QUESTIONS.length}
+                </span>
+              </div>
+
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={currentQuestion.id}
+                  initial={{ opacity: 0, x: 24 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -24 }}
+                  transition={{ duration: 0.22, ease: 'easeOut' }}
+                >
+                  <h2 className="text-xl font-black tracking-tight text-slate-900 dark:text-white leading-snug">
+                    {currentQuestion.title}
+                  </h2>
+                  <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+                    {currentQuestion.helper}
+                  </p>
+
+                  {currentQuestion.kind === 'single' && (
+                    <section className="mt-5 rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 overflow-hidden">
+                      <textarea
+                        ref={textareaRef}
+                        value={answers[currentQuestion.id]}
+                        onChange={handleChange(currentQuestion.id)}
+                        placeholder={currentQuestion.placeholder}
+                        maxLength={2000}
+                        autoFocus
+                        className="w-full min-h-[180px] bg-transparent px-4 py-3 text-sm text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none resize-none transition-colors"
+                      />
+                      <div className="px-4 pb-2 text-right text-[11px] text-slate-400 dark:text-slate-500">
+                        {answers[currentQuestion.id].length}/2000
+                      </div>
+                    </section>
+                  )}
+
+                  {currentQuestion.kind === 'multi' && (
+                    <div className="mt-5 space-y-4">
+                      {currentQuestion.fields.map((field, idx) => (
+                        <section
+                          key={field.id}
+                          className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 overflow-hidden"
+                        >
+                          <div className="px-4 pt-3 pb-1 flex items-center gap-2">
+                            <span
+                              className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-[11px] font-bold ${
+                                field.label === '잘한 점'
+                                  ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300'
+                                  : 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+                              }`}
+                            >
+                              {idx + 1}
+                            </span>
+                            <label className="text-sm font-bold text-slate-700 dark:text-slate-200">
+                              {field.label}
+                            </label>
+                          </div>
+                          <textarea
+                            value={answers[field.id]}
+                            onChange={handleChange(field.id)}
+                            placeholder={field.placeholder}
+                            maxLength={1000}
+                            autoFocus={idx === 0}
+                            className="w-full min-h-[120px] bg-transparent px-4 py-2 text-sm text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none resize-none transition-colors"
+                          />
+                          <div className="px-4 pb-2 text-right text-[11px] text-slate-400 dark:text-slate-500">
+                            {answers[field.id].length}/1000
+                          </div>
+                        </section>
+                      ))}
+                    </div>
+                  )}
+                </motion.div>
+              </AnimatePresence>
+            </>
+          )}
+
+          {phase === 'review' && draft && (
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.22, ease: 'easeOut' }}
+            >
+              <div className="mb-3 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400">
+                <Check size={14} />
+                <span>초안 리뷰</span>
+              </div>
+              <h2 className="text-xl font-black tracking-tight text-slate-900 dark:text-white leading-snug">
+                생성된 초안을 확인하고 다듬어주세요
+              </h2>
+              <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+                마음에 들지 않는 부분은 자유롭게 수정할 수 있어요. 수정을 마치면 일기 작성 페이지로
+                넘어갑니다.
+              </p>
+
+              {/* 본문 편집 */}
+              <section className="mt-5 rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 overflow-hidden">
+                <div className="px-4 pt-3 pb-1">
+                  <label className="text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400">
+                    일기 본문
+                  </label>
+                </div>
+                <textarea
+                  value={draft.content}
+                  onChange={updateDraftContent}
+                  maxLength={2500}
+                  className="w-full min-h-[260px] bg-transparent px-4 py-3 text-sm leading-relaxed text-slate-900 dark:text-white focus:outline-none resize-none transition-colors"
+                />
+                <div className="px-4 pb-2 text-right text-[11px] text-slate-400 dark:text-slate-500">
+                  {draft.content.length}/2500
+                </div>
+              </section>
+            </motion.div>
+          )}
+
+          {error && (
+            <p className="mt-4 text-sm text-red-500 dark:text-red-400 text-center">{error}</p>
+          )}
+        </div>
+      </main>
+
+      {/* 하단 액션 바 */}
+      <div className="fixed bottom-0 left-0 right-0 md:left-16 z-30 border-t border-slate-200 dark:border-slate-800 bg-white/90 dark:bg-slate-900/90 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:supports-[backdrop-filter]:bg-slate-900/70 px-4 py-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]">
+        <div className="mx-auto flex w-full max-w-2xl items-center gap-3">
+          <button
+            onClick={handlePrev}
+            disabled={isGenerating}
+            className="px-4 py-3.5 rounded-xl text-sm font-semibold text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors disabled:opacity-50"
+          >
+            {phase === 'review' ? '질문으로' : '이전'}
+          </button>
+          {phase === 'questions' ? (
+            <button
+              onClick={handleNext}
+              disabled={!canProceed || isGenerating}
+              className={`flex flex-1 items-center justify-center gap-2 py-3.5 rounded-xl text-sm font-bold transition-colors ${
+                canProceed && !isGenerating
+                  ? 'bg-teal-500 text-white hover:bg-teal-600'
+                  : 'bg-slate-100 dark:bg-slate-800 text-slate-400 dark:text-slate-500 cursor-not-allowed'
+              }`}
+            >
+              {isGenerating ? (
+                <>
+                  <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                  초안 작성 중...
+                </>
+              ) : isLastStep ? (
+                <>
+                  <Sparkles size={18} />
+                  초안 작성
+                </>
+              ) : (
+                <>
+                  다음
+                  <ChevronRight size={18} />
+                </>
+              )}
+            </button>
+          ) : (
+            <button
+              onClick={handleProceed}
+              disabled={isGenerating || !draft}
+              className="flex flex-1 items-center justify-center gap-2 py-3.5 rounded-xl text-sm font-bold bg-teal-500 text-white hover:bg-teal-600 transition-colors disabled:opacity-50"
+            >
+              <Check size={18} />
+              일기 작성으로 이동
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DiaryDraftPage;

--- a/components/pages/DiaryEditPage.tsx
+++ b/components/pages/DiaryEditPage.tsx
@@ -21,6 +21,8 @@ const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) =>
   const [isLoadingDiary, setIsLoadingDiary] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const shouldScrollToEndRef = useRef(false);
   const MAX_IMAGES = 9;
   const [loadingImagesCount, setLoadingImagesCount] = useState(0);
 
@@ -67,6 +69,18 @@ const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) =>
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
 
+  useEffect(() => {
+    if (shouldScrollToEndRef.current && scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTo({
+        left: scrollContainerRef.current.scrollWidth,
+        behavior: 'smooth',
+      });
+      if (loadingImagesCount === 0) {
+        shouldScrollToEndRef.current = false;
+      }
+    }
+  }, [images, loadingImagesCount]);
+
   const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files) return;
@@ -74,6 +88,7 @@ const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) =>
     const filesToProcess = Math.min(files.length, remaining);
     if (filesToProcess <= 0) return;
 
+    shouldScrollToEndRef.current = true;
     setLoadingImagesCount(filesToProcess);
 
     Array.from<File>(files).slice(0, filesToProcess).forEach((file) => {
@@ -141,12 +156,17 @@ const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) =>
 
               {/* 사진 */}
               <section className="rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-5">
-                <label className="block text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400 mb-3">
-                  사진 {images.length}/{MAX_IMAGES}
-                </label>
-                <div className="grid grid-cols-3 gap-3">
+                <div className="flex items-center justify-between mb-3">
+                  <label className="block text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400">
+                    사진
+                  </label>
+                  <span className="text-[11px] text-slate-400 dark:text-slate-500">
+                    {images.length}/{MAX_IMAGES}
+                  </span>
+                </div>
+                <div ref={scrollContainerRef} className="flex gap-3 overflow-x-auto no-scrollbar">
                   {images.map((img, i) => (
-                    <div key={i} className="relative aspect-square rounded-xl overflow-hidden group">
+                    <div key={i} className="relative w-24 h-24 flex-shrink-0 rounded-xl overflow-hidden group">
                       <img
                         src={img}
                         alt=""
@@ -168,14 +188,14 @@ const DiaryEditPage: React.FC<DiaryEditPageProps> = ({ id, onBack, onSaved }) =>
                     Array.from({ length: loadingImagesCount }).map((_, i) => (
                       <div
                         key={`loading-${i}`}
-                        className="aspect-square rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse"
+                        className="w-24 h-24 flex-shrink-0 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse"
                       />
                     ))}
                   {images.length < MAX_IMAGES && (
                     <button
                       type="button"
                       onClick={() => fileInputRef.current?.click()}
-                      className="aspect-square rounded-xl border-2 border-dashed border-slate-200 dark:border-slate-700 flex flex-col items-center justify-center gap-1 text-slate-400 dark:text-slate-500 hover:border-teal-400 hover:text-teal-500 transition-colors"
+                      className="w-24 h-24 flex-shrink-0 rounded-xl border-2 border-dashed border-slate-200 dark:border-slate-700 flex flex-col items-center justify-center gap-1 text-slate-400 dark:text-slate-500 hover:border-teal-400 hover:text-teal-500 transition-colors"
                     >
                       <Camera size={20} />
                       <span className="text-[10px] font-medium">사진 추가</span>

--- a/components/pages/DiaryListPage.tsx
+++ b/components/pages/DiaryListPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Plus, BookOpen } from 'lucide-react';
+import { Plus, BookOpen, PenLine, FileEdit } from 'lucide-react';
 import { Diary } from '../../types';
 import { getDiaries } from '../../api/diaryMock';
 import DiaryCard from '../diary/DiaryCard';
@@ -9,10 +9,13 @@ import ScrollAwareFab from '../common/ScrollAwareFab';
 import DiaryWritePage from './DiaryWritePage';
 import DiaryDetailPage from './DiaryDetailPage';
 import DiaryEditPage from './DiaryEditPage';
+import DiaryDraftPage from './DiaryDraftPage';
+import { DiaryDraftResult } from '../../api/diaryDraft';
 
 type DiaryPanel =
   | { type: 'none' }
-  | { type: 'write' }
+  | { type: 'write'; draft?: DiaryDraftResult }
+  | { type: 'writeDraft' }
   | { type: 'detail'; id: string }
   | { type: 'edit'; id: string };
 
@@ -21,6 +24,7 @@ const DiaryListPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [panel, setPanel] = useState<DiaryPanel>({ type: 'none' });
+  const [isFabMenuOpen, setIsFabMenuOpen] = useState(false);
   const panelHistoryRef = useRef(false);
   const mainRef = useRef<HTMLElement>(null);
 
@@ -44,6 +48,7 @@ const DiaryListPage: React.FC = () => {
     window.history.pushState({ diaryPanel: true }, '');
     panelHistoryRef.current = true;
     setPanel(next);
+    setIsFabMenuOpen(false);
   };
 
   const closePanel = () => {
@@ -140,11 +145,51 @@ const DiaryListPage: React.FC = () => {
       </main>
 
       <ScrollAwareFab
-        onClick={() => openPanel({ type: 'write' })}
+        onClick={() => setIsFabMenuOpen((prev) => !prev)}
         ariaLabel="일기 작성"
       >
         <Plus size={28} />
       </ScrollAwareFab>
+
+      <AnimatePresence>
+        {isFabMenuOpen && (
+          <>
+            <motion.div
+              key="fab-menu-backdrop"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              onClick={() => setIsFabMenuOpen(false)}
+              className="fixed inset-0 z-30 bg-black/20 dark:bg-black/40"
+            />
+            <motion.div
+              key="fab-menu"
+              initial={{ opacity: 0, y: 12, scale: 0.96 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 12, scale: 0.96 }}
+              transition={{ duration: 0.18, ease: 'easeOut' }}
+              className="fixed right-6 bottom-44 z-40 w-44 overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-900 shadow-2xl"
+            >
+              <button
+                onClick={() => openPanel({ type: 'write' })}
+                className="flex w-full items-center gap-3 px-4 py-3.5 text-left text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+              >
+                <PenLine size={18} className="text-teal-500" />
+                일기 작성
+              </button>
+              <div className="h-px bg-slate-100 dark:bg-slate-800" />
+              <button
+                onClick={() => openPanel({ type: 'writeDraft' })}
+                className="flex w-full items-center gap-3 px-4 py-3.5 text-left text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+              >
+                <FileEdit size={18} className="text-teal-500" />
+                일기 초안 작성
+              </button>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
 
       <AnimatePresence>
         {panel.type !== 'none' && (
@@ -160,6 +205,15 @@ const DiaryListPage: React.FC = () => {
               <DiaryWritePage
                 onBack={closePanel}
                 onSaved={() => { loadDiaries(); closePanel(); }}
+                initialContent={panel.draft?.content}
+                initialAchievement={panel.draft?.achievement}
+                initialRegret={panel.draft?.regret}
+              />
+            )}
+            {panel.type === 'writeDraft' && (
+              <DiaryDraftPage
+                onBack={closePanel}
+                onDraftGenerated={(draft) => openPanel({ type: 'write', draft })}
               />
             )}
             {panel.type === 'detail' && (

--- a/components/pages/DiaryWritePage.tsx
+++ b/components/pages/DiaryWritePage.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Camera, X } from 'lucide-react';
 import { useDiaryForm } from '../../hooks/useDiaryForm';
@@ -13,9 +13,18 @@ import UniversalHeader from '../layout/UniversalHeader';
 interface DiaryWritePageProps {
   onBack: () => void;
   onSaved: () => void;
+  initialContent?: string;
+  initialAchievement?: string[];
+  initialRegret?: string[];
 }
 
-const DiaryWritePage: React.FC<DiaryWritePageProps> = ({ onBack, onSaved }) => {
+const DiaryWritePage: React.FC<DiaryWritePageProps> = ({
+  onBack,
+  onSaved,
+  initialContent,
+  initialAchievement,
+  initialRegret,
+}) => {
   const {
     date, setDate,
     emotion, setEmotion,
@@ -29,12 +38,33 @@ const DiaryWritePage: React.FC<DiaryWritePageProps> = ({ onBack, onSaved }) => {
     images, setImages,
     isSubmitting, submitError, canSubmit,
     handleCreate,
-  } = useDiaryForm({ onCreateSuccess: onSaved });
+  } = useDiaryForm({
+    onCreateSuccess: onSaved,
+    initialValues: {
+      content: initialContent ?? '',
+      achievement: initialAchievement,
+      regret: initialRegret,
+    },
+  });
 
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const shouldScrollToEndRef = useRef(false);
 
   const MAX_IMAGES = 9;
   const [loadingImagesCount, setLoadingImagesCount] = useState(0);
+
+  useEffect(() => {
+    if (shouldScrollToEndRef.current && scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTo({
+        left: scrollContainerRef.current.scrollWidth,
+        behavior: 'smooth',
+      });
+      if (loadingImagesCount === 0) {
+        shouldScrollToEndRef.current = false;
+      }
+    }
+  }, [images, loadingImagesCount]);
 
   const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
@@ -43,6 +73,7 @@ const DiaryWritePage: React.FC<DiaryWritePageProps> = ({ onBack, onSaved }) => {
     const filesToProcess = Math.min(files.length, remaining);
     if (filesToProcess <= 0) return;
 
+    shouldScrollToEndRef.current = true;
     setLoadingImagesCount(filesToProcess);
     const newImages: string[] = [];
     let completedCount = 0;
@@ -102,13 +133,13 @@ const DiaryWritePage: React.FC<DiaryWritePageProps> = ({ onBack, onSaved }) => {
                 <label className="block text-[11px] font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400">
                   사진
                 </label>
-                <span className="text-[11px] font-medium text-slate-400 dark:text-slate-500">
+                <span className="text-[11px] text-slate-400 dark:text-slate-500">
                   {images.length}/{MAX_IMAGES}
                 </span>
               </div>
-              <div className="grid grid-cols-3 gap-3">
+              <div ref={scrollContainerRef} className="flex gap-3 overflow-x-auto no-scrollbar">
                 {images.map((img, i) => (
-                  <div key={i} className="relative aspect-square rounded-xl overflow-hidden group">
+                  <div key={i} className="relative w-24 h-24 flex-shrink-0 rounded-xl overflow-hidden group">
                     <img
                       src={img}
                       alt=""
@@ -127,13 +158,13 @@ const DiaryWritePage: React.FC<DiaryWritePageProps> = ({ onBack, onSaved }) => {
                   </div>
                 ))}
                 {Array.from({ length: loadingImagesCount }).map((_, i) => (
-                  <div key={`loading-${i}`} className="aspect-square rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
+                  <div key={`loading-${i}`} className="w-24 h-24 flex-shrink-0 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
                 ))}
                 {images.length < MAX_IMAGES && (
                   <button
                     type="button"
                     onClick={() => fileInputRef.current?.click()}
-                    className="aspect-square rounded-xl border-2 border-dashed border-slate-200 dark:border-slate-700 flex flex-col items-center justify-center gap-1 text-slate-400 dark:text-slate-500 hover:border-teal-400 hover:text-teal-500 transition-colors"
+                    className="w-24 h-24 flex-shrink-0 rounded-xl border-2 border-dashed border-slate-200 dark:border-slate-700 flex flex-col items-center justify-center gap-1 text-slate-400 dark:text-slate-500 hover:border-teal-400 hover:text-teal-500 transition-colors"
                   >
                     <Camera size={20} />
                     <span className="text-[10px] font-medium">사진 추가</span>


### PR DESCRIPTION
## 변경 사항
- FAB 플로팅 메뉴: '일기 작성' / '일기 초안 작성' 분리
- DiaryDraftPage: 5문항 순차 입력 → 초안 생성 → 본문 인라인 편집 리뷰 → 일기 작성 페이지 전달
- DiaryWritePage: initialContent/achievement/regret prop로 초안 수용
- diaryDraft.ts: 답변→일기 합성 함수 (LLM 교체 대비 구조)

## 흐름
1. FAB 클릭 → '일기 초안 작성' 선택
2. 5문항 순차 입력 (하루 사건, 기억에 남는 순간, 컨디션, 잘한 점/아쉬운 점, 클로징)
3. 초안 생성 → 리뷰 단계에서 본문 인라인 편집
4. '일기 작성으로 이동' → DiaryWritePage에서 초안 기반 일기 작성/저장

## 참고
- 현재 LLM 미연결, 클라이언트 합성 mock 구현
- api/diaryDraft.ts의 generateDiaryDraft 함수 교체 시 실제 LLM 연동 가능

Closes #47